### PR TITLE
Recycler view refactoring tests

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/ProjectManagerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/ProjectManagerTest.java
@@ -55,7 +55,6 @@ public class ProjectManagerTest extends InstrumentationTestCase {
 		super.setUp();
 		UtilUi.updateScreenWidthAndHeight(getInstrumentation().getTargetContext());
 		projectManager = ProjectManager.getInstance();
-		Reflection.setPrivateField(ProjectManager.class, ProjectManager.getInstance(), "asynchronousTask", false);
 	}
 
 	@Override

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/AddItemToUserListActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/AddItemToUserListActionTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.content.actions;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -54,7 +55,7 @@ public class AddItemToUserListActionTest extends AndroidTestCase {
 	protected void setUp() throws Exception {
 		actionFactory = new ActionFactory();
 		testSprite = new SingleSprite("testSprite");
-		project = new Project(null, "testProject");
+		project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().setCurrentScene(project.getDefaultScene());
 		ProjectManager.getInstance().getCurrentScene().getDataContainer().addProjectUserList(TEST_USERLIST_NAME);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/AskActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/AskActionTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.content.actions;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -43,7 +44,7 @@ public class AskActionTest extends AndroidTestCase {
 	@Override
 	protected void setUp() throws Exception {
 		testSprite = new Sprite("testSprite");
-		project = new Project(null, "testProject");
+		project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().getCurrentScene().getDataContainer().addProjectUserVariable(TEST_USERVARIABLE);
 		userVariableForAnswer = ProjectManager.getInstance().getCurrentScene().getDataContainer()

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/ChangeVariableActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/ChangeVariableActionTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.content.actions;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -44,7 +45,7 @@ public class ChangeVariableActionTest extends AndroidTestCase {
 	@Override
 	protected void setUp() throws Exception {
 		testSprite = new SingleSprite("testSprite");
-		project = new Project(null, "testProject");
+		project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().getCurrentScene().getDataContainer().addProjectUserVariable(TEST_USERVARIABLE);
 		userVariable = ProjectManager.getInstance().getCurrentScene().getDataContainer()

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/DeleteItemOfUserListActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/DeleteItemOfUserListActionTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.content.actions;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -50,7 +51,7 @@ public class DeleteItemOfUserListActionTest extends AndroidTestCase {
 	protected void setUp() throws Exception {
 		actionFactory = new ActionFactory();
 		testSprite = new SingleSprite("testSprite");
-		project = new Project(null, "testProject");
+		project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().getCurrentScene().getDataContainer().addProjectUserList(TEST_USER_LIST_NAME);
 		userList = ProjectManager.getInstance().getCurrentScene().getDataContainer()

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/IfLogicActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/IfLogicActionTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.content.actions;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
@@ -70,7 +71,7 @@ public class IfLogicActionTest extends AndroidTestCase {
 	protected void setUp() throws Exception {
 		super.setUp();
 		testSprite = new SingleSprite("testSprite");
-		project = new Project(null, "testProject");
+		project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		testSprite.removeAllScripts();
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().setCurrentSprite(new SingleSprite("testSprite1"));

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/IfOnEdgeBounceActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/IfOnEdgeBounceActionTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.content.actions;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.InstrumentationTestCase;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
@@ -67,7 +68,7 @@ public class IfOnEdgeBounceActionTest extends InstrumentationTestCase {
 		ActionFactory factory = sprite.getActionFactory();
 		ifOnEdgeBounceAction = factory.createIfOnEdgeBounceAction(sprite);
 
-		Project project = new Project(null, "Test", false);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), "Test", false);
 		project.getXmlHeader().virtualScreenWidth = SCREEN_WIDTH;
 		project.getXmlHeader().virtualScreenHeight = SCREEN_HEIGHT;
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/InsertItemintoUserListActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/InsertItemintoUserListActionTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.content.actions;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -51,7 +52,7 @@ public class InsertItemintoUserListActionTest extends AndroidTestCase {
 	protected void setUp() throws Exception {
 		actionFactory = new ActionFactory();
 		testSprite = new SingleSprite("testSingleSprite");
-		project = new Project(null, "testProject");
+		project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().getCurrentScene().getDataContainer().addProjectUserList(TEST_USERLIST_NAME);
 		userList = ProjectManager.getInstance().getCurrentScene().getDataContainer()

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/RepeatUntilActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/RepeatUntilActionTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.content.actions;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.InstrumentationTestCase;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
@@ -63,7 +64,7 @@ public class RepeatUntilActionTest extends InstrumentationTestCase {
 	@Override
 	protected void setUp() throws Exception {
 		testSprite = new SingleSprite("testSprite");
-		project = new Project(null, "testProject");
+		project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		testScript = new StartScript();
 		testSprite.removeAllScripts();
 		ProjectManager.getInstance().setProject(project);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/ReplaceItemInUserListActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/ReplaceItemInUserListActionTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.content.actions;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -51,7 +52,7 @@ public class ReplaceItemInUserListActionTest extends AndroidTestCase {
 	protected void setUp() throws Exception {
 		actionFactory = new ActionFactory();
 		testSprite = new SingleSprite("testSprite");
-		project = new Project(null, "testProject");
+		project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().getCurrentScene().getDataContainer().addProjectUserList(TEST_USERLIST_NAME);
 		userList = ProjectManager.getInstance().getCurrentScene().getDataContainer()

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/SetNfcTagActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/SetNfcTagActionTest.java
@@ -24,6 +24,7 @@ package org.catrobat.catroid.test.content.actions;
 
 import android.nfc.FormatException;
 import android.nfc.NdefMessage;
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -55,7 +56,7 @@ public class SetNfcTagActionTest extends AndroidTestCase {
 
 	@Override
 	protected void setUp() throws Exception {
-		project = new Project(null, "testProject");
+		project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		ProjectManager.getInstance().setProject(project);
 		super.setUp();
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/SetVariableActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/SetVariableActionTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.content.actions;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -43,7 +44,7 @@ public class SetVariableActionTest extends AndroidTestCase {
 	@Override
 	protected void setUp() throws Exception {
 		testSprite = new SingleSprite("testSprite");
-		project = new Project(null, "testProject");
+		project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().getCurrentScene().getDataContainer().addProjectUserVariable(TEST_USERVARIABLE);
 		userVariable = ProjectManager.getInstance().getCurrentScene().getDataContainer()

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/ShowTextActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/ShowTextActionTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.content.actions;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
@@ -42,7 +43,7 @@ public class ShowTextActionTest extends AndroidTestCase {
 
 	public void testShowVariablesVisibilitySameVariableNameAcrossSprites() {
 		Sprite sprite = new Sprite(SPRITE_NAME);
-		Project project = new Project(null, "testProject");
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		project.getDefaultScene().addSprite(sprite);
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().setCurrentSprite(sprite);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/WaitUntilActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/WaitUntilActionTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.content.actions;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -48,7 +49,7 @@ public class WaitUntilActionTest extends AndroidTestCase {
 	protected void setUp() throws Exception {
 		super.setUp();
 		testSprite = new SingleSprite("testSprite");
-		project = new Project(null, "testProject");
+		project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		testSprite.removeAllScripts();
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().setCurrentSprite(new SingleSprite("testSprite1"));

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/WhenConditionBecomesTrueActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/WhenConditionBecomesTrueActionTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.content.actions;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -56,7 +57,7 @@ public class WhenConditionBecomesTrueActionTest extends AndroidTestCase {
 	protected void setUp() throws Exception {
 		super.setUp();
 		testSprite = new Sprite("testSprite");
-		project = new Project(null, "testProject");
+		project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().setCurrentSprite(new Sprite("testSprite1"));

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/bricks/BrickCloneTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/bricks/BrickCloneTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.content.bricks;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 import android.util.Log;
 
@@ -198,7 +199,7 @@ public class BrickCloneTest extends AndroidTestCase {
 
 	private <T extends Brick> void testVariableReferences(Class<T> typeOfBrick) throws Exception {
 		// set up project
-		Project project = new Project(null, TestUtils.DEFAULT_TEST_PROJECT_NAME);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), TestUtils.DEFAULT_TEST_PROJECT_NAME);
 		ProjectManager.getInstance().setProject(project);
 		project.getDefaultScene().addSprite(sprite);
 		StartScript script = new StartScript();

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/script/ScriptTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/script/ScriptTest.java
@@ -57,7 +57,6 @@ public class ScriptTest extends AndroidTestCase {
 	@Override
 	protected void tearDown() throws Exception {
 		super.tearDown();
-		StorageHandler.deleteDir(Utils.buildProjectPath(DEFAULT_TEST_PROJECT_NAME));
 	}
 
 	public void testAddBricks() {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/LookTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/LookTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.content.sprite;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.InstrumentationTestCase;
 
 import com.badlogic.gdx.graphics.Color;
@@ -81,7 +82,7 @@ public class LookTest extends InstrumentationTestCase {
 	public void testImagePath() {
 		String projectName = "myProject";
 		String fileName = "blubb";
-		project = new Project(null, projectName);
+		project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		project.getDefaultScene().addSprite(sprite);
 		ProjectManager.getInstance().setProject(project);
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/devices/arduino/ArduinoSettingsTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/devices/arduino/ArduinoSettingsTest.java
@@ -24,6 +24,7 @@
 package org.catrobat.catroid.test.devices.arduino;
 
 import android.content.Context;
+import android.support.test.InstrumentationRegistry;
 import android.test.InstrumentationTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -75,7 +76,7 @@ public class ArduinoSettingsTest extends InstrumentationTestCase {
 	}
 
 	private void createProjectArduino() {
-		Project projectArduino = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
+		Project projectArduino = new Project(InstrumentationRegistry.getTargetContext(), UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
 		Sprite sprite = new SingleSprite("Arduino");
 		StartScript startScript = new StartScript();
 		ArduinoSendPWMValueBrick arduinoArduinoSendPWMValueBrick = new ArduinoSendPWMValueBrick(3, 255);
@@ -83,7 +84,6 @@ public class ArduinoSettingsTest extends InstrumentationTestCase {
 		sprite.addScript(startScript);
 		projectArduino.getDefaultScene().addSprite(sprite);
 
-		Reflection.setPrivateField(ProjectManager.getInstance(), "asynchronousTask", false);
 		ProjectManager.getInstance().setProject(projectArduino);
 		ProjectManager.getInstance().saveProject(context);
 		ProjectManager.getInstance().setProject(null);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/devices/phiro/PhiroSettingsTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/devices/phiro/PhiroSettingsTest.java
@@ -24,6 +24,7 @@
 package org.catrobat.catroid.test.devices.phiro;
 
 import android.content.Context;
+import android.support.test.InstrumentationRegistry;
 import android.test.InstrumentationTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -78,7 +79,7 @@ public class PhiroSettingsTest extends InstrumentationTestCase {
 	}
 
 	private void createProjectPhiro() {
-		Project projectPhiro = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
+		Project projectPhiro = new Project(InstrumentationRegistry.getTargetContext(), UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
 		Sprite sprite = new SingleSprite("Phiro");
 		StartScript startScript = new StartScript();
 		SetSizeToBrick setSizeToBrick = new SetSizeToBrick(new Formula(new FormulaElement(FormulaElement.ElementType.SENSOR,
@@ -87,7 +88,6 @@ public class PhiroSettingsTest extends InstrumentationTestCase {
 		sprite.addScript(startScript);
 		projectPhiro.getDefaultScene().addSprite(sprite);
 
-		Reflection.setPrivateField(ProjectManager.getInstance(), "asynchronousTask", false);
 		ProjectManager.getInstance().setProject(projectPhiro);
 		ProjectManager.getInstance().saveProject(context);
 		ProjectManager.getInstance().setProject(null);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/drone/DroneTestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/drone/DroneTestUtils.java
@@ -22,6 +22,8 @@
  */
 package org.catrobat.catroid.test.drone;
 
+import android.support.test.InstrumentationRegistry;
+
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
@@ -39,7 +41,7 @@ public abstract class DroneTestUtils {
 	private static final int DEFAULT_MOVE_POWER_IN_PERCENT = 20;
 
 	public static void createDefaultDroneProject() {
-		Project project = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
 		Sprite sprite = new SingleSprite("DroneBricksTest");
 		Script script = new StartScript();
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/DataContainerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/DataContainerTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.formulaeditor;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -82,7 +83,7 @@ public class DataContainerTest extends AndroidTestCase {
 	}
 	@Override
 	protected void setUp() {
-		Project project = new Project(null, "testProject");
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		firstSprite = new SingleSprite("firstSprite");
 		StartScript startScript = new StartScript();
 		ChangeSizeByNBrick changeBrick = new ChangeSizeByNBrick(10);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestObject.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestObject.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.formulaeditor;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 import android.util.Log;
 
@@ -56,7 +57,7 @@ public class ParserTestObject extends AndroidTestCase {
 
 	@Override
 	protected void setUp() {
-		Project project = new Project(null, TestUtils.DEFAULT_TEST_PROJECT_NAME);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), TestUtils.DEFAULT_TEST_PROJECT_NAME);
 		ProjectManager.getInstance().setProject(project);
 		testSprite = new SingleSprite("sprite");
 		ProjectManager.getInstance().setCurrentSprite(testSprite);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestSensors.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestSensors.java
@@ -23,6 +23,7 @@
 package org.catrobat.catroid.test.formulaeditor;
 
 import android.graphics.Point;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.annotation.UiThreadTest;
 import android.support.test.rule.UiThreadTestRule;
 import android.support.test.runner.AndroidJUnit4;
@@ -221,7 +222,7 @@ public class ParserTestSensors {
 	}
 
 	private void createProject() {
-		this.project = new Project(null, "testProject");
+		this.project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		firstSprite = new SingleSprite("zwoosh");
 		startScript1 = new StartScript();
 		Brick changeBrick = new ChangeSizeByNBrick(10);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestStringFunctions.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestStringFunctions.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.formulaeditor;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -51,7 +52,7 @@ public class ParserTestStringFunctions extends AndroidTestCase {
 	@Override
 	protected void setUp() {
 		testSprite = new SingleSprite("testsprite");
-		Project project = new Project(null, UiTestUtils.PROJECTNAME1);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), UiTestUtils.PROJECTNAME1);
 		project.getDefaultScene().addSprite(testSprite);
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().setCurrentSprite(testSprite);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestUserLists.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestUserLists.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.formulaeditor;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -104,7 +105,7 @@ public class ParserTestUserLists extends AndroidTestCase {
 
 	@Override
 	protected void setUp() {
-		Project project = new Project(null, "testProject");
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		firstSprite = new SingleSprite("firstSprite");
 		StartScript startScript = new StartScript();
 		ChangeSizeByNBrick changeBrick = new ChangeSizeByNBrick(10);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestUserVariables.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestUserVariables.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.formulaeditor;
 
+import android.support.test.InstrumentationRegistry;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.ProjectManager;
@@ -57,7 +58,7 @@ public class ParserTestUserVariables extends AndroidTestCase {
 
 	@Override
 	protected void setUp() {
-		Project project = new Project(null, "testProject");
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), "testProject");
 		firstSprite = new SingleSprite("firstSprite");
 		StartScript startScript = new StartScript();
 		ChangeSizeByNBrick changeBrick = new ChangeSizeByNBrick(10);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/io/StorageHandlerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/io/StorageHandlerTest.java
@@ -310,8 +310,6 @@ public class StorageHandlerTest extends InstrumentationTestCase {
 				NXTSensor.Sensor.LIGHT_INACTIVE, NXTSensor.Sensor.ULTRASONIC
 		};
 
-		Reflection.setPrivateField(ProjectManager.getInstance(), "asynchronousTask", false);
-
 		Project project = generateMultiplePermissionsProject();
 		ProjectManager.getInstance().setProject(project);
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/TestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/TestUtils.java
@@ -26,6 +26,7 @@ import android.app.NotificationManager;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+import android.support.test.InstrumentationRegistry;
 import android.util.Log;
 import android.util.SparseArray;
 
@@ -148,7 +149,7 @@ public final class TestUtils {
 
 	public static Project createTestProjectOnLocalStorageWithCatrobatLanguageVersionAndName(
 			float catrobatLanguageVersion, String name) {
-		Project project = new Project(null, name);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), name);
 		project.setCatrobatLanguageVersion(catrobatLanguageVersion);
 
 		Sprite firstSprite = new SingleSprite("cat");
@@ -165,7 +166,7 @@ public final class TestUtils {
 
 	public static List<Brick> createTestProjectWithWrongIfClauseReferences() {
 		ProjectManager projectManager = ProjectManager.getInstance();
-		Project project = new Project(null, CORRUPT_PROJECT_NAME);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), CORRUPT_PROJECT_NAME);
 		Sprite firstSprite = new SingleSprite("corruptReferences");
 
 		Script testScript = new StartScript();
@@ -219,7 +220,7 @@ public final class TestUtils {
 	}
 
 	public static Project createEmptyProject() {
-		Project project = new Project(null, EMPTY_PROJECT);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), EMPTY_PROJECT);
 		StorageHandler.getInstance().saveProject(project);
 		return project;
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/UtilFileSizeTranslationsTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/UtilFileSizeTranslationsTest.java
@@ -85,7 +85,7 @@ public class UtilFileSizeTranslationsTest {
 
 	public void createProjectWithFiles() {
 		String projectName = "fileSizeArabicTest";
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		StorageHandler.getInstance().saveProject(project);
 
 		projectFolder = new File(Utils.buildProjectPath(projectName));

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/UtilFileTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/UtilFileTest.java
@@ -23,6 +23,7 @@
 package org.catrobat.catroid.test.utiltests;
 
 import android.os.Environment;
+import android.support.test.InstrumentationRegistry;
 import android.test.InstrumentationTestCase;
 import android.util.Log;
 
@@ -131,7 +132,7 @@ public class UtilFileTest extends InstrumentationTestCase {
 	}
 
 	public void testGetProjectNames() {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		ProjectManager.getInstance().setProject(project);
 		Sprite sprite = new SingleSprite("new sprite");
 		project.getDefaultScene().addSprite(sprite);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/SmokeTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/SmokeTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.uiespresso;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.IdlingRegistry;
 import android.support.test.espresso.IdlingResource;
 import android.support.test.runner.AndroidJUnit4;
@@ -31,7 +32,9 @@ import org.catrobat.catroid.ui.MainMenuActivity;
 import org.catrobat.catroid.ui.ProjectActivity;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
 import org.catrobat.catroid.uiespresso.util.UiTestUtils;
+import org.catrobat.catroid.uiespresso.util.actions.CustomActions;
 import org.catrobat.catroid.uiespresso.util.rules.DontGenerateDefaultProjectActivityInstrumentationRule;
+import org.catrobat.catroid.utils.Utils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -45,6 +48,7 @@ import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.typeText;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
@@ -96,12 +100,17 @@ public class SmokeTest {
 		//onView(withText(toUpperCase(R.string.spritelist_background_headline))).check(matches(isDisplayed()));
 		//onView(withText(toUpperCase(R.string.sprites))).check(matches(isDisplayed()));
 
+		//open scene
+		String sceneName = UiTestUtils.getResources().getString(R.string.default_scene_name, 1);
+		onView(withText(sceneName))
+				.perform(click());
+
 		//add sprite
 		onView(withId(R.id.button_add))
 				.perform(click());
 
 		//check if new object dialog is displayed
-		onView(withText(R.string.new_sprite_dialog_title))
+		onView(withText(R.string.new_look_dialog_title))
 				.check(matches(isDisplayed()));
 		//cancel by back
 		pressBack();

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/AskBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/AskBrickTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.uiespresso.content.brick.app;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -74,7 +75,7 @@ public class AskBrickTest {
 	}
 
 	private void createProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		Sprite sprite1 = new Sprite("testSprite");
 		Script sprite1StartScript = new StartScript();
 		sprite1.addScript(sprite1StartScript);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/BrickValueParameterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/BrickValueParameterTest.java
@@ -160,6 +160,7 @@ import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
 import org.catrobat.catroid.uiespresso.util.UiTestUtils;
+import org.catrobat.catroid.uiespresso.util.actions.CustomActions;
 import org.catrobat.catroid.uiespresso.util.matchers.BrickCategoryListMatchers;
 import org.catrobat.catroid.uiespresso.util.matchers.BrickPrototypeListMatchers;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
@@ -180,6 +181,7 @@ import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withSpinnerText;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
@@ -574,12 +576,12 @@ public class BrickValueParameterTest {
 				R.id.brick_when_background_spinner,
 				R.string.brick_variable_spinner_create_new_variable);
 
-		checkIfBrickAtPositionShowsText(SetBackgroundBrick.class, 0, R.string.brick_set_look);
+		checkIfBrickAtPositionShowsText(SetBackgroundBrick.class, 0, R.string.brick_set_background);
 		checkIfBrickAtPositionShowsSpinnerWithText(SetBackgroundBrick.class, 0,
 				R.id.brick_set_look_spinner,
 				R.string.brick_variable_spinner_create_new_variable);
 
-		checkIfBrickAtPositionShowsText(SetBackgroundAndWaitBrick.class, 0, R.string.brick_set_look);
+		checkIfBrickAtPositionShowsText(SetBackgroundAndWaitBrick.class, 0, R.string.brick_set_background);
 		checkIfBrickAtPositionShowsText(SetBackgroundAndWaitBrick.class, 0, R.string.brick_and_wait);
 		checkIfBrickAtPositionShowsSpinnerWithText(SetBackgroundAndWaitBrick.class, 0,
 				R.id.brick_set_look_spinner,
@@ -1150,7 +1152,7 @@ public class BrickValueParameterTest {
 	private void createProject(String projectName) {
 		String nameSpriteTwo = "testSpriteTwo";
 
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		Sprite spriteOne = new Sprite(nameSpriteOne);
 		project.getDefaultScene().addSprite(spriteOne);
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/BroadcastBricksTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/BroadcastBricksTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.uiespresso.content.brick.app;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -135,7 +136,7 @@ public class BroadcastBricksTest {
 	}
 
 	private Script createProjectAndGetStartScriptWithImages(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		Sprite sprite = new Sprite("testSprite");
 		Script script = new StartScript();
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/DeleteItemOfUserListBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/DeleteItemOfUserListBrickTest.java
@@ -33,6 +33,7 @@ import org.catrobat.catroid.uiespresso.annotations.Flaky;
 import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.actions.CustomActions;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,6 +47,7 @@ import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.longClick;
 import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
@@ -126,7 +128,11 @@ public class DeleteItemOfUserListBrickTest {
 				.perform(longClick());
 		onView(withText(R.string.delete))
 				.perform(click());
+		onView(withText(R.string.deletion_alert_yes))
+				.perform(click());
+
 		pressBack();
+
 		onView(allOf(withText(secondUserListName), isDisplayed()))
 				.check(doesNotExist());
 		pressBack();

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/PlaySoundAndWaitBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/PlaySoundAndWaitBrickTest.java
@@ -67,6 +67,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
+import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRVAtPosition;
 import static org.hamcrest.Matchers.allOf;
 
 @RunWith(AndroidJUnit4.class)
@@ -126,7 +127,7 @@ public class PlaySoundAndWaitBrickTest {
 				.checkShowsText(soundName);
 		pressBack();
 
-		deleteSoundByName(soundName);
+		deleteSound(0);
 
 		onView(withId(R.id.program_menu_button_scripts))
 				.perform(click());
@@ -175,7 +176,7 @@ public class PlaySoundAndWaitBrickTest {
 
 		pressBack();
 
-		renameSound(soundName, newName);
+		renameSound(0, soundName, newName);
 
 		onView(withId(R.id.program_menu_button_scripts))
 				.perform(click());
@@ -186,14 +187,14 @@ public class PlaySoundAndWaitBrickTest {
 				.checkShowsText(newName);
 	}
 
-	private void deleteSoundByName(String soundName) {
+	private void deleteSound(int position) {
 		onView(withId(R.id.program_menu_button_sounds))
 				.perform(click());
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.delete))
 				.perform(click());
-		onView(withText(soundName))
-				.perform(click());
+		onRVAtPosition(position)
+				.performCheckItem();
 		onView(withContentDescription(R.string.done))
 				.perform(click());
 
@@ -208,14 +209,14 @@ public class PlaySoundAndWaitBrickTest {
 		pressBack();
 	}
 
-	private void renameSound(String oldName, String newName) {
+	private void renameSound(int position, String oldName, String newName) {
 		onView(withId(R.id.program_menu_button_sounds))
 				.perform(click());
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.rename))
 				.perform(click());
-		onView(withText(oldName))
-				.perform(click());
+		onRVAtPosition(position)
+				.performCheckItem();
 		onView(withContentDescription(R.string.done))
 				.perform(click());
 
@@ -265,7 +266,7 @@ public class PlaySoundAndWaitBrickTest {
 
 		soundFile = FileTestUtils.saveFileToProject(projectName, ProjectManager.getInstance().getCurrentScene()
 						.getName(),
-				"longsound.mp3", RESOURCE_SOUND, InstrumentationRegistry.getTargetContext(),
+				"longsound.mp3", RESOURCE_SOUND, InstrumentationRegistry.getContext(),
 				FileTestUtils.FileTypes.SOUND);
 		SoundInfo soundInfo = new SoundInfo();
 		soundInfo.setFileName(soundFile.getName());
@@ -273,7 +274,7 @@ public class PlaySoundAndWaitBrickTest {
 
 		soundFile2 = FileTestUtils.saveFileToProject(projectName, ProjectManager.getInstance().getCurrentScene()
 						.getName(),
-				"testsoundui.mp3", RESOURCE_SOUND2, InstrumentationRegistry.getTargetContext(),
+				"testsoundui.mp3", RESOURCE_SOUND2, InstrumentationRegistry.getContext(),
 				FileTestUtils.FileTypes.SOUND);
 		SoundInfo soundInfo2 = new SoundInfo();
 		soundInfo2.setFileName(soundFile2.getName());

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/PointToBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/PointToBrickTest.java
@@ -73,7 +73,7 @@ public class PointToBrickTest {
 				.checkShowsText(R.string.brick_variable_spinner_create_new_variable)
 				.performSelect(R.string.brick_variable_spinner_create_new_variable);
 
-		onView(withText(R.string.new_sprite_dialog_title))
+		onView(withText(R.string.new_look_dialog_title))
 				.check(matches(isDisplayed()));
 	}
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/ReplaceItemInUserListTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/ReplaceItemInUserListTest.java
@@ -31,6 +31,7 @@ import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.actions.CustomActions;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
 import org.junit.Before;
 import org.junit.Rule;
@@ -47,6 +48,7 @@ import static android.support.test.espresso.action.ViewActions.typeText;
 import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
@@ -104,6 +106,8 @@ public class ReplaceItemInUserListTest {
 		onView(allOf(withText(secondUserListName), isDisplayed()))
 				.perform(longClick());
 		onView(withText(R.string.delete))
+				.perform(click());
+		onView(withText(R.string.deletion_alert_yes))
 				.perform(click());
 
 		pressBack();

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/WhenNfcBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/WhenNfcBrickTest.java
@@ -329,7 +329,7 @@ public class WhenNfcBrickTest {
 	}
 
 	private void createProjectWithNfcAndSetVariable() {
-		Project project = new Project(null, "nfcTestProject");
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), "nfcTestProject");
 
 		DataContainer dataContainer = project.getDefaultScene().getDataContainer();
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/rtl/RtlBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/rtl/RtlBrickTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.uiespresso.content.brick.rtl;
 
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.support.test.InstrumentationRegistry;
@@ -169,6 +170,7 @@ import org.catrobat.catroid.physics.content.bricks.SetPhysicsObjectTypeBrick;
 import org.catrobat.catroid.physics.content.bricks.SetVelocityBrick;
 import org.catrobat.catroid.physics.content.bricks.TurnLeftSpeedBrick;
 import org.catrobat.catroid.physics.content.bricks.TurnRightSpeedBrick;
+import org.catrobat.catroid.ui.ProjectActivity;
 import org.catrobat.catroid.ui.SettingsActivity;
 import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
@@ -226,10 +228,8 @@ public class RtlBrickTest {
 
 	@Before
 	public void setUp() throws Exception {
-		createProject("RtlBricksTest");
 		SettingsActivity.setLanguageSharedPreference(getTargetContext(), "ar");
-		baseActivityTestRule.launchActivity(null);
-
+		createProject("RtlBricksTest");
 		SharedPreferences sharedPreferences = PreferenceManager
 				.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext());
 
@@ -240,6 +240,7 @@ public class RtlBrickTest {
 				enabledByThisTestPeripheralCategories.add(category);
 			}
 		}
+		baseActivityTestRule.launchActivity(null);
 	}
 
 	@After
@@ -256,7 +257,7 @@ public class RtlBrickTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void eventBricks() throws Exception {
-		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertEquals(arLocale.getDisplayLanguage(), Locale.getDefault().getDisplayLanguage());
 		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
 		openCategory(R.string.category_event);
 
@@ -297,7 +298,7 @@ public class RtlBrickTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void controlBricks() throws Exception {
-		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertEquals(arLocale.getDisplayLanguage(), Locale.getDefault().getDisplayLanguage());
 		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
 		openCategory(R.string.category_control);
 
@@ -350,7 +351,7 @@ public class RtlBrickTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void motionBricks() throws Exception {
-		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertEquals(arLocale.getDisplayLanguage(), Locale.getDefault().getDisplayLanguage());
 		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
 		openCategory(R.string.category_motion);
 
@@ -424,7 +425,7 @@ public class RtlBrickTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void soundBricks() throws Exception {
-		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertEquals(arLocale.getDisplayLanguage(), Locale.getDefault().getDisplayLanguage());
 		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
 		openCategory(R.string.category_sound);
 
@@ -459,7 +460,7 @@ public class RtlBrickTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void looksBricks() throws Exception {
-		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertEquals(arLocale.getDisplayLanguage(), Locale.getDefault().getDisplayLanguage());
 		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
 		openCategory(R.string.category_looks);
 
@@ -536,7 +537,7 @@ public class RtlBrickTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void penBricks() throws Exception {
-		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertEquals(arLocale.getDisplayLanguage(), Locale.getDefault().getDisplayLanguage());
 		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
 		openCategory(R.string.category_pen);
 
@@ -562,7 +563,7 @@ public class RtlBrickTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void dataBricks() throws Exception {
-		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertEquals(arLocale.getDisplayLanguage(), Locale.getDefault().getDisplayLanguage());
 		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
 		openCategory(R.string.category_data);
 
@@ -600,7 +601,7 @@ public class RtlBrickTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void legoNxtBricks() throws Exception {
-		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertEquals(arLocale.getDisplayLanguage(), Locale.getDefault().getDisplayLanguage());
 		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
 		openCategory(R.string.category_lego_nxt);
 
@@ -620,7 +621,7 @@ public class RtlBrickTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void legoEv3Bricks() throws Exception {
-		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertEquals(arLocale.getDisplayLanguage(), Locale.getDefault().getDisplayLanguage());
 		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
 		openCategory(R.string.category_lego_ev3);
 
@@ -643,7 +644,7 @@ public class RtlBrickTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void arDroneBricks() throws Exception {
-		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertEquals(arLocale.getDisplayLanguage(), Locale.getDefault().getDisplayLanguage());
 		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
 		openCategory(R.string.category_drone);
 
@@ -690,7 +691,7 @@ public class RtlBrickTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void jumpingSumoBricks() throws Exception {
-		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertEquals(arLocale.getDisplayLanguage(), Locale.getDefault().getDisplayLanguage());
 		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
 		openCategory(R.string.category_jumping_sumo);
 
@@ -731,7 +732,7 @@ public class RtlBrickTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void phiroBricks() throws Exception {
-		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertEquals(arLocale.getDisplayLanguage(), Locale.getDefault().getDisplayLanguage());
 		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
 		openCategory(R.string.category_phiro);
 
@@ -765,7 +766,7 @@ public class RtlBrickTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void arduinoBricks() throws Exception {
-		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertEquals(arLocale.getDisplayLanguage(), Locale.getDefault().getDisplayLanguage());
 		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
 		openCategory(R.string.category_arduino);
 
@@ -779,7 +780,7 @@ public class RtlBrickTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void raspPiBricks() throws Exception {
-		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertEquals(arLocale.getDisplayLanguage(), Locale.getDefault().getDisplayLanguage());
 		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
 		openCategory(R.string.category_raspi);
 
@@ -812,7 +813,7 @@ public class RtlBrickTest {
 	private void createProject(String projectName) {
 		String nameSpriteTwo = "testSpriteTwo";
 
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		Sprite spriteOne = new Sprite("testSpriteOne");
 		project.getDefaultScene().addSprite(spriteOne);
 
@@ -822,6 +823,7 @@ public class RtlBrickTest {
 
 		project.getDefaultScene().addSprite(spriteTwo);
 		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentScene(project.getDefaultScene());
 		ProjectManager.getInstance().setCurrentSprite(spriteTwo);
 	}
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/AskBrickStageTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/AskBrickStageTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.uiespresso.content.brick.stage;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -103,7 +104,7 @@ public class AskBrickStageTest {
 
 	private void createProject(String projectName) {
 		String userVariableName = "TempVariable";
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		Sprite sprite1 = new Sprite("testSprite");
 		Script sprite1StartScript = new StartScript();
 		sprite1.addScript(sprite1StartScript);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/BroadcastBricksStageTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/BroadcastBricksStageTest.java
@@ -91,7 +91,7 @@ public class BroadcastBricksStageTest {
 	private Script createProjectAndGetStartScriptWithImages(String projectName) {
 		String defaultMessage = "defaultMessage";
 
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		Sprite sprite = new Sprite("testSprite");
 		Script script = new StartScript();
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/SayBubbleBrickStageTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/SayBubbleBrickStageTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.uiespresso.content.brick.stage;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -69,7 +70,7 @@ public class SayBubbleBrickStageTest {
 	private void createProject(String projectName) {
 		String sayString = "say something";
 
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		sprite = new Sprite("testSprite");
 		Script script = new StartScript();
 		script.addBrick(new SayBubbleBrick(sayString));

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/SayForBubbleBrickStageTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/SayForBubbleBrickStageTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.uiespresso.content.brick.stage;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -78,7 +79,7 @@ public class SayForBubbleBrickStageTest {
 	private void createProject(String projectName) {
 		String sayString = "say something";
 		float duration = 2f;
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		sprite = new Sprite("testSprite");
 		Script script = new StartScript();
 		sprite.addScript(script);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/ThinkBubbleBrickStageTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/ThinkBubbleBrickStageTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.uiespresso.content.brick.stage;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -69,7 +70,7 @@ public class ThinkBubbleBrickStageTest {
 	private void createProject(String projectName) {
 		String thinkString = "say something";
 
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		sprite = new Sprite("testSprite");
 		Script script = new StartScript();
 		script.addBrick(new ThinkBubbleBrick(thinkString));

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/ThinkForBubbleBrickStageTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/ThinkForBubbleBrickStageTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.uiespresso.content.brick.stage;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -78,7 +79,7 @@ public class ThinkForBubbleBrickStageTest {
 	private void createProject(String projectName) {
 		String sayString = "think something";
 		float duration = 2f;
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		sprite = new Sprite("testSprite");
 		Script script = new StartScript();
 		sprite.addScript(script);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/WhenNfcBrickHardwareStageTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/WhenNfcBrickHardwareStageTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.uiespresso.content.brick.stage;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import junit.framework.Assert;
@@ -81,7 +82,7 @@ public class WhenNfcBrickHardwareStageTest {
 	}
 
 	private void createProjectWithNfcAndSetVariable() {
-		Project project = new Project(null, "whenNfcBrickHardwareTest");
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), "whenNfcBrickHardwareTest");
 		DataContainer dataContainer = project.getDefaultScene().getDataContainer();
 		numDetectedTags = dataContainer.addProjectUserVariable(NUM_DETECTED_TAGS);
 		readTagId = dataContainer.addProjectUserVariable(READ_TAG_ID);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/WhenNfcBrickStageFromScriptTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/WhenNfcBrickStageFromScriptTest.java
@@ -24,6 +24,7 @@
 package org.catrobat.catroid.uiespresso.content.brick.stage;
 
 import android.nfc.NdefMessage;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import junit.framework.Assert;
@@ -149,7 +150,7 @@ public class WhenNfcBrickStageFromScriptTest {
 	}
 
 	private Script createProjectWithNfcAndSetVariable() {
-		Project project = new Project(null, "nfcTestProject");
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), "nfcTestProject");
 
 		DataContainer dataContainer = project.getDefaultScene().getDataContainer();
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/WhenNfcBrickStageTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/WhenNfcBrickStageTest.java
@@ -24,6 +24,7 @@
 package org.catrobat.catroid.uiespresso.content.brick.stage;
 
 import android.nfc.NdefMessage;
+import android.support.test.InstrumentationRegistry;
 
 import junit.framework.Assert;
 
@@ -77,7 +78,7 @@ public class WhenNfcBrickStageTest {
 	private WhenNfcScript scriptUnderTest;
 
 	private WhenNfcScript createProjectWithNfcAndSetVariable() {
-		Project project = new Project(null, "nfcStageTestProject");
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), "nfcStageTestProject");
 
 		DataContainer dataContainer = project.getDefaultScene().getDataContainer();
 		readTagId = dataContainer.addProjectUserVariable(UiNFCTestUtils.READ_TAG_ID);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/utils/BrickTestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/utils/BrickTestUtils.java
@@ -23,6 +23,8 @@
 
 package org.catrobat.catroid.uiespresso.content.brick.utils;
 
+import android.support.test.InstrumentationRegistry;
+
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
@@ -47,7 +49,7 @@ public final class BrickTestUtils {
 	}
 
 	public static Script createProjectAndGetStartScript(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		Sprite sprite = new Sprite("testSprite");
 		Script script = new StartScript();
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/facedetection/FaceDetectionFormulaEditorComputeDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/facedetection/FaceDetectionFormulaEditorComputeDialogTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.uiespresso.facedetection;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -94,7 +95,7 @@ public class FaceDetectionFormulaEditorComputeDialogTest {
 	}
 
 	public Project createProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		Sprite sprite = new Sprite("testSprite");
 		Script script = new StartScript();
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/facedetection/FaceDetectionResourceStartedTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/facedetection/FaceDetectionResourceStartedTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.uiespresso.facedetection;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -138,7 +139,7 @@ public class FaceDetectionResourceStartedTest {
 	}
 
 	private void createProject() {
-		Project project = new Project(null, "FaceDetectionResourceStartedTest");
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), "FaceDetectionResourceStartedTest");
 		Sprite sprite = new Sprite("testSprite");
 		Script startScript = new StartScript();
 		SetSizeToBrick setSizeToBrick = new SetSizeToBrick(formula);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorKeyboardTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorKeyboardTest.java
@@ -22,6 +22,8 @@
  */
 package org.catrobat.catroid.uiespresso.formulaeditor;
 
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -63,7 +65,9 @@ public class FormulaEditorKeyboardTest {
 	@Before
 	public void setUp() throws Exception {
 		createProject("formulaEditorKeyboardTest");
-		baseActivityTestRule.launchActivity(null);
+		Intent intent = new Intent();
+		intent.putExtra(SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
+		baseActivityTestRule.launchActivity(intent);
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class})
@@ -85,7 +89,7 @@ public class FormulaEditorKeyboardTest {
 		onView(withId(R.id.formula_editor_keyboard_1)).perform(click());
 		onView(withId(R.id.formula_editor_keyboard_ok)).perform(click());
 
-		onView(withId(R.id.formula_editor_edit_field))
+		onView(withId(R.id.brick_set_variable_edit_text))
 				.check(matches(withText("1234567890"
 						+ UiTestUtils.getResourcesString(R.string.formula_editor_decimal_mark) + "1 ")));
 	}
@@ -110,7 +114,7 @@ public class FormulaEditorKeyboardTest {
 		onView(withId(R.id.formula_editor_keyboard_1)).perform(click());
 		onView(withId(R.id.formula_editor_keyboard_ok)).perform(click());
 
-		onView(withId(R.id.formula_editor_edit_field))
+		onView(withId(R.id.brick_set_variable_edit_text))
 				.check(matches(withText("( 1 ) + 1 - 1 × 1 ÷ 1 = 1 ")));
 	}
 
@@ -131,7 +135,7 @@ public class FormulaEditorKeyboardTest {
 
 		onView(withId(R.id.formula_editor_keyboard_ok))
 				.perform(click());
-		onView(withId(R.id.formula_editor_edit_field))
+		onView(withId(R.id.brick_set_variable_edit_text))
 				.check(matches(withText("'Foo' ")));
 	}
 
@@ -140,7 +144,7 @@ public class FormulaEditorKeyboardTest {
 	}
 
 	public Project createProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		Sprite sprite = new Sprite("testSprite");
 		Script script = new StartScript();
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorTest.java
@@ -22,6 +22,8 @@
  */
 package org.catrobat.catroid.uiespresso.formulaeditor;
 
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -59,7 +61,9 @@ public class FormulaEditorTest {
 	@Before
 	public void setUp() throws Exception {
 		createProject("formulaEditorInputTest");
-		baseActivityTestRule.launchActivity(null);
+		Intent intent = new Intent();
+		intent.putExtra(SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
+		baseActivityTestRule.launchActivity(intent);
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class})
@@ -81,7 +85,7 @@ public class FormulaEditorTest {
 	}
 
 	public static Project createProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		Sprite sprite = new Sprite("testSprite");
 		Script script = new StartScript();
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/BroadcastAndWaitForDeletedClonesRegressionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/BroadcastAndWaitForDeletedClonesRegressionTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.uiespresso.stage;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -73,7 +74,7 @@ public class BroadcastAndWaitForDeletedClonesRegressionTest {
 	}
 
 	private void createProject() {
-		Project project = new Project(null, "BroadcastForDeletedClonesRegressionTest");
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), "BroadcastForDeletedClonesRegressionTest");
 		ProjectManager.getInstance().setProject(project);
 
 		Sprite sprite = new Sprite("testSprite");

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/BroadcastForClonesRegressionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/BroadcastForClonesRegressionTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.uiespresso.stage;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import junit.framework.Assert;
@@ -97,7 +98,7 @@ public class BroadcastForClonesRegressionTest {
 	}
 
 	private void createProject() {
-		Project project = new Project(null, "BroadcastForClonesRegressionTest");
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), "BroadcastForClonesRegressionTest");
 		ProjectManager.getInstance().setProject(project);
 		DataContainer dataContainer = project.getDefaultScene().getDataContainer();
 		userVariable = dataContainer.addProjectUserVariable(VARIABLE_NAME);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/BroadcastForDeletedClonesRegressionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/BroadcastForDeletedClonesRegressionTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.uiespresso.stage;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -73,7 +74,7 @@ public class BroadcastForDeletedClonesRegressionTest {
 	}
 
 	private void createProject() {
-		Project project = new Project(null, "BroadcastForDeletedClonesRegressionTest");
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), "BroadcastForDeletedClonesRegressionTest");
 		ProjectManager.getInstance().setProject(project);
 
 		Sprite sprite = new Sprite("testSprite");

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/ObjectVariableTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/ObjectVariableTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.uiespresso.stage;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -109,8 +110,9 @@ public class ObjectVariableTest {
 	}
 
 	private void createProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentScene(project.getDefaultScene());
 		ProjectManager.getInstance().getCurrentScene().addSprite(new SingleSprite("background"));
 		ProjectManager.getInstance().getCurrentScene().addSprite(new SingleSprite("sprite1"));
 		ProjectManager.getInstance().getCurrentScene().addSprite(new SingleSprite("sprite2"));

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/StageSimpleTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/StageSimpleTest.java
@@ -83,7 +83,7 @@ public class StageSimpleTest {
 		ScreenValues.SCREEN_HEIGHT = PROJECT_HEIGHT;
 		ScreenValues.SCREEN_WIDTH = PROJECT_WIDTH;
 
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 
 		// blue Sprite
 		Sprite blueSprite = new SingleSprite("blueSprite");

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/testsuites/AllEspressoTestsDebugSuite.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/testsuites/AllEspressoTestsDebugSuite.java
@@ -109,6 +109,7 @@ import org.catrobat.catroid.uiespresso.content.brick.app.VariableBrickTest;
 import org.catrobat.catroid.uiespresso.content.brick.app.WaitBrickTest;
 import org.catrobat.catroid.uiespresso.content.brick.app.WhenNfcBrickTest;
 import org.catrobat.catroid.uiespresso.content.brick.app.WhenStartedBrickTest;
+import org.catrobat.catroid.uiespresso.content.brick.rtl.RtlBrickTest;
 import org.catrobat.catroid.uiespresso.content.brick.stage.AskBrickStageTest;
 import org.catrobat.catroid.uiespresso.content.brick.stage.BroadcastBricksStageTest;
 import org.catrobat.catroid.uiespresso.content.brick.stage.CameraResourceTest;
@@ -140,128 +141,24 @@ import org.catrobat.catroid.uiespresso.ui.dialog.DeleteSpriteDialogTest;
 import org.catrobat.catroid.uiespresso.ui.dialog.FormulaEditorComputeDialogTest;
 import org.catrobat.catroid.uiespresso.ui.dialog.RenameSpriteDialogTest;
 import org.catrobat.catroid.uiespresso.ui.dialog.TermsOfUseDialogTest;
+import org.catrobat.catroid.uiespresso.ui.fragment.RenameLookFragmentTest;
+import org.catrobat.catroid.uiespresso.ui.fragment.RenameSoundFragmentTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-		PocketMusicActivityTest.class,
-		SmokeTest.class,
-		FlakyTestTest.class,
-		FaceDetectionFormulaEditorComputeDialogTest.class,
-		FaceDetectionResourceStartedTest.class,
-		LegoEv3PlayToneBrickTest.class,
-		ThinkBubbleBrickTest.class,
-		SetYBrickTest.class,
-		ComeToFrontBrickTest.class,
-		ARDroneTurnLeftBrickTest.class,
-		SetBrightnessBrickTest.class,
-		HideBrickTest.class,
-		ChangeTransparencyByNBrickTest.class,
-		SetRotationStyleBrickTest.class,
-		RepeatUntilBrickTest.class,
-		SceneTransmitionBrickTest.class,
-		DragNDropBricksTest.class,
-		GoNStepsBackTest.class,
-		PhiroMoveMotorForwardBrickTest.class,
-		RepeatBrickTest.class,
-		PointInDirectionBrickTest.class,
-		BroadcastBricksTest.class,
-		SpeakAndWaitBrickTest.class,
-		SpeakBrickTest.class,
-		VariableBrickTest.class,
-		ChangeVolumeByNBrickTest.class,
-		AskBrickTest.class,
-		BrickValueParameterTest.class,
-		ArduinoSendPWMValueBrickTest.class,
-		ARDroneTurnRightBrickTest.class,
-		NextLookBrickTest.class,
-		ARDroneMoveRightBrickTest.class,
-		ThinkForBubbleBrickTest.class,
-		ChangeColorByNBrickTest.class,
-		ArduinoSendDigitalValueBrickTest.class,
-		PlaceAtBrickTest.class,
-		ARDroneMoveForwardBrickTest.class,
-		DeleteItemOfUserListBrickTest.class,
-		ReplaceItemInUserListTest.class,
-		StopAllSoundsBrickTest.class,
-		StopScriptBrickTest.class,
-		SetTransparencyBrickTest.class,
-		GlideToBrickTest.class,
-		MoveNStepsBrickTest.class,
-		WaitBrickTest.class,
-		PlaySoundAndWaitBrickTest.class,
-		ChangeYByNBrickTest.class,
-		LegoNXTMotorStopBrickTest.class,
-		PhiroIfBrickTest.class,
-		PhiroMoveMotorBackwardBrickTest.class,
-		TurnRightBrickTest.class,
-		ARDroneMoveUpBrickTest.class,
-		PhiroPlayToneBrickTest.class,
-		GoToBrickTest.class,
-		WhenNfcBrickTest.class,
-		SetVolumeToBrickTest.class,
-		SetSizeToBrickTest.class,
-		PointToBrickTest.class,
-		PhiroStopMotorBrickTest.class,
-		LegoEV3SetLedBrickTest.class,
-		LegoEv3MotorMoveBrickTest.class,
-		NoteBrickTest.class,
-		LegoNxtPlayToneBrickTest.class,
-		SayForBubbleBrickTest.class,
-		SetLookByIndexBrickTest.class,
-		ChangeBrightnessByNBrickTest.class,
-		ChangeXByNBrickTest.class,
-		ShowBrickTest.class,
-		ARDroneMoveDownBrickTest.class,
-		SetColorBrickTest.class,
-		SayBubbleBrickTest.class,
-		CameraBrickTest.class,
-		ARDroneMoveLeftBrickTest.class,
-		LoopBrickTest.class,
-		ShowTextBrickTest.class,
-		LegoEv3MotorStopBrickTest.class,
-		LegoNxtMotorTurnAngleBrickTest.class,
-		ForeverBrickTest.class,
-		ChangeSizeByNBrickTest.class,
-		AddItemToUserListTest.class,
-		ClearGraphicEffectBrickTest.class,
-		IfThenBrickTest.class,
-		LegoNXTMotorMoveBrickTest.class,
-		WhenStartedBrickTest.class,
-		LegoEv3MotorTurnAngleBrickTest.class,
-		ARDroneMoveBackwardBrickTest.class,
-		TurnLeftBrickTest.class,
-		SetXBrickTest.class,
-		IfThenElseBrickTest.class,
-		WhenNfcBrickStageTest.class,
-		CameraResourceTest.class,
-		SayBubbleBrickStageTest.class,
-		SayForBubbleBrickStageTest.class,
-		WhenNfcBrickStageFromScriptTest.class,
-		ThinkBubbleBrickStageTest.class,
-		BroadcastBricksStageTest.class,
-		ThinkForBubbleBrickStageTest.class,
-		AskBrickStageTest.class,
-		StagePausedTest.class,
-		BroadcastForClonesRegressionTest.class,
-		StageSimpleTest.class,
-		ObjectVariableTest.class,
-		MultipleBroadcastsTest.class,
-		BroadcastReceiverRegressionTest.class,
-		FormulaEditorKeyboardTest.class,
-		FormulaEditorTest.class,
-		LanguageSwitchMainMenuTest.class,
-		HindiNumberAtShowDetailsAtProjectActivityTest.class,
-		ProjectActivityNumberOfBricksRegressionTest.class,
-		SettingsActivityTest.class,
-		FormulaEditorComputeDialogTest.class,
-		RenameSpriteDialogTest.class,
-		DeleteSpriteDialogTest.class,
-		DeleteSoundDialogTest.class,
-		TermsOfUseDialogTest.class,
-		DeleteLookDialogTest.class,
-		AboutDialogTest.class
+		BroadcastBricksTest.class, // known bug, fails also in develop
+		DeleteItemOfUserListBrickTest.class, // fails rightly, user list still available in bricks spinner
+		IfThenBrickTest.class, // fails, probably not rightly, looping brick references wrong, something took care of
+		// this in the past when creating projects in that manner, but not anymore....
+		IfThenElseBrickTest.class, // fails, probably not rightly, looping brick references wrong, something took
+		// care of this in the past when creating projects in that manner, but not anymore....
+		FormulaEditorKeyboardTest.class, // fails rightly, something majorly wrong with formula editor
+		ObjectVariableTest.class, // fails rightly, something wrong with layer change / initial layer in which sprite
+		// lives
+		ProjectActivityNumberOfBricksRegressionTest.class, // fails rightly, number of bricks incorrect
+		HindiNumberAtShowDetailsAtProjectActivityTest.class, // fails rightly, number of bricks incorrect
 })
 public class AllEspressoTestsDebugSuite {
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectActivityNumberOfBricksRegressionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectActivityNumberOfBricksRegressionTest.java
@@ -23,6 +23,8 @@
 
 package org.catrobat.catroid.uiespresso.ui.activity;
 
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -38,7 +40,9 @@ import org.catrobat.catroid.ui.ProjectActivity;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
 import org.catrobat.catroid.uiespresso.util.UiTestUtils;
+import org.catrobat.catroid.uiespresso.util.actions.CustomActions;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,11 +50,15 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
+import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRVAtPosition;
 import static org.hamcrest.Matchers.allOf;
 
 @RunWith(AndroidJUnit4.class)
@@ -63,25 +71,39 @@ public class ProjectActivityNumberOfBricksRegressionTest {
 	@Before
 	public void setUp() {
 		createProject();
-		baseActivityTestRule.launchActivity(null);
-		//showDetails();
+		Intent intent = new Intent();
+		intent.putExtra(ProjectActivity.EXTRA_FRAGMENT_POSITION, ProjectActivity.FRAGMENT_SPRITES);
+		baseActivityTestRule.launchActivity(intent);
+
+		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
+		onView(withText(R.string.show_details)).perform(click());
+	}
+
+	@After
+	public void tearDown() {
+		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
+		onView(withText(R.string.hide_details)).perform(click());
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void numberOfBricksDetailsRegressionTest() throws Exception {
-		onView(allOf(withId(R.id.details_left_bottom), isDisplayed()))
+		onRVAtPosition(1).onChildView(R.id.details_left_bottom)
 				.check(matches(withText(UiTestUtils.getResourcesString(R.string.number_of_scripts).concat(" 2"))));
 
-		onView(allOf(withId(R.id.details_right_bottom), isDisplayed()))
+		//TODO: this is breaking because currently script start bricks arent counted as bricks
+		onRVAtPosition(1).onChildView(R.id.details_right_bottom)
 				.check(matches(withText(UiTestUtils.getResourcesString(R.string.number_of_bricks).concat(" 7"))));
 
-		onView(allOf(withId(R.id.details_left_top), isDisplayed()))
+		onRVAtPosition(1).onChildView(R.id.details_left_top)
 				.check(matches(withText(UiTestUtils.getResourcesString(R.string.number_of_looks).concat(" 2"))));
+
+		onRVAtPosition(1).onChildView(R.id.details_right_top)
+				.check(matches(withText(UiTestUtils.getResourcesString(R.string.number_of_sounds).concat(" 0"))));
 	}
 
 	private void createProject() {
-		Project project = new Project(null, "ProjectActivityNumberOfBricksRegressionTest");
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), "ProjectActivityNumberOfBricksRegressionTest");
 
 		Sprite firstSprite = new SingleSprite("firstSprite");
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/rtl/HindiNumberAtShowDetailsAtProjectActivityTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/rtl/HindiNumberAtShowDetailsAtProjectActivityTest.java
@@ -23,6 +23,8 @@
 
 package org.catrobat.catroid.uiespresso.ui.activity.rtl;
 
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
@@ -40,6 +42,7 @@ import org.catrobat.catroid.ui.SettingsActivity;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
 import org.catrobat.catroid.uiespresso.util.UiTestUtils;
+import org.catrobat.catroid.uiespresso.util.actions.CustomActions;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
 import org.junit.After;
 import org.junit.Before;
@@ -52,14 +55,18 @@ import java.util.Locale;
 
 import static android.support.test.InstrumentationRegistry.getTargetContext;
 import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
+import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRVAtPosition;
 import static org.hamcrest.Matchers.allOf;
 
 @RunWith(AndroidJUnit4.class)
@@ -75,39 +82,46 @@ public class HindiNumberAtShowDetailsAtProjectActivityTest {
 
 	@Before
 	public void setUp() {
-		createProject();
 		SettingsActivity.setLanguageSharedPreference(getTargetContext(), "ar");
-		baseActivityTestRule.launchActivity(null);
-		// setShowDetails()
+		createProject();
+		Intent intent = new Intent();
+		intent.putExtra(ProjectActivity.EXTRA_FRAGMENT_POSITION, ProjectActivity.FRAGMENT_SPRITES);
+		baseActivityTestRule.launchActivity(intent);
+
+		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
+		onView(withText(R.string.show_details)).perform(click());
 	}
 
 	@After
 	public void tearDown() {
+		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
+		onView(withText(R.string.hide_details)).perform(click());
 		SettingsActivity.removeLanguageSharedPreference(getTargetContext());
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void hindiNumbers() throws Exception {
-		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertEquals(arLocale.getDisplayLanguage(), Locale.getDefault().getDisplayLanguage());
 		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
 
-		onView(allOf(withId(R.id.details_left_bottom), isDisplayed()))
+		onRVAtPosition(1).onChildView(R.id.details_left_bottom)
 				.check(matches(withText(UiTestUtils.getResourcesString(R.string.number_of_scripts) + " " + expectedHindiNumberOfScripts)));
 
-		onView(allOf(withId(R.id.details_right_bottom), isDisplayed()))
+		//TODO: this is breaking because currently script start bricks arent counted as bricks
+		onRVAtPosition(1).onChildView(R.id.details_right_bottom)
 				.check(matches(withText(UiTestUtils.getResourcesString(R.string.number_of_bricks) + " " + expectedHindiNumberOfBricks)));
 
-		onView(allOf(withId(R.id.details_left_top), isDisplayed()))
+		onRVAtPosition(1).onChildView(R.id.details_left_top)
 				.check(matches(withText(UiTestUtils.getResourcesString(R.string.number_of_looks) + " " + expectedHindiNumberOfLooks)));
 
-		onView(allOf(withId(R.id.details_right_top), isDisplayed()))
+		onRVAtPosition(1).onChildView(R.id.details_right_top)
 				.check(matches(withText(UiTestUtils.getResourcesString(R.string.number_of_sounds) + " " + expectedHindiNumberOfSounds)));
 	}
 
 	private void createProject() {
 		String projectName = "HindiNumberTest";
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 
 		Sprite firstSprite = new SingleSprite("firstSprite");
 
@@ -135,6 +149,6 @@ public class HindiNumberAtShowDetailsAtProjectActivityTest {
 		project.getDefaultScene().addSprite(firstSprite);
 
 		ProjectManager.getInstance().setProject(project);
-		ProjectManager.getInstance().setCurrentSprite(firstSprite);
+		ProjectManager.getInstance().setCurrentScene(project.getDefaultScene());
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/DeleteLookDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/DeleteLookDialogTest.java
@@ -36,8 +36,9 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.FileTestUtils;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
-import org.catrobat.catroid.uitest.util.UiTestUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,6 +59,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withContentDesc
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
+import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRVAtPosition;
 import static org.hamcrest.Matchers.allOf;
 
 @RunWith(AndroidJUnit4.class)
@@ -85,10 +87,13 @@ public class DeleteLookDialogTest {
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.delete)).perform(click());
 
-		onView(withText(toBeDeletedLookName)).perform(click());
-		onView(withContentDescription("Done")).perform(click());
+		onRVAtPosition(1)
+				.performCheckItem();
 
-		onView(withText(R.string.dialog_confirm_delete_look_title)).inRoot(isDialog())
+		onView(withContentDescription(R.string.done)).perform(click());
+
+		onView(withText(UiTestUtils.getResources().getQuantityString(R.plurals.delete_looks, 1)))
+				.inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
 		onView(withText(R.string.dialog_confirm_delete_look_message)).inRoot(isDialog())
@@ -112,10 +117,13 @@ public class DeleteLookDialogTest {
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.delete)).perform(click());
 
-		onView(withText(toBeDeletedLookName)).perform(click());
-		onView(withContentDescription("Done")).perform(click());
+		onRVAtPosition(1)
+				.performCheckItem();
 
-		onView(withText(R.string.dialog_confirm_delete_look_title)).inRoot(isDialog())
+		onView(withContentDescription(R.string.done)).perform(click());
+
+		onView(withText(UiTestUtils.getResources().getQuantityString(R.plurals.delete_looks, 1)))
+				.inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
 		onView(withText(R.string.dialog_confirm_delete_look_message)).inRoot(isDialog())
@@ -134,7 +142,7 @@ public class DeleteLookDialogTest {
 	}
 
 	private void createProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 
 		Sprite sprite = new SingleSprite("testSprite");
 		project.getDefaultScene().addSprite(sprite);
@@ -142,16 +150,16 @@ public class DeleteLookDialogTest {
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().setCurrentSprite(sprite);
 
-		File imageFile = UiTestUtils.saveFileToProject(
+		File imageFile = FileTestUtils.saveFileToProject(
 				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "catroid_sunglasses.png",
 				org.catrobat.catroid.test.R.drawable.catroid_banzai, InstrumentationRegistry.getTargetContext(),
-				UiTestUtils.FileTypes.IMAGE
+				FileTestUtils.FileTypes.IMAGE
 		);
 
-		File imageFile2 = UiTestUtils.saveFileToProject(
+		File imageFile2 = FileTestUtils.saveFileToProject(
 				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "catroid_banzai.png",
 				org.catrobat.catroid.test.R.drawable.catroid_banzai, InstrumentationRegistry.getTargetContext(),
-				UiTestUtils.FileTypes.IMAGE
+				FileTestUtils.FileTypes.IMAGE
 		);
 
 		List<LookData> lookDataList = ProjectManager.getInstance().getCurrentSprite().getLookList();

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/DeleteSoundDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/DeleteSoundDialogTest.java
@@ -36,8 +36,9 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.FileTestUtils;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
-import org.catrobat.catroid.uitest.util.UiTestUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,6 +59,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withContentDesc
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
+import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRVAtPosition;
 import static org.hamcrest.Matchers.allOf;
 
 @RunWith(AndroidJUnit4.class)
@@ -85,10 +87,13 @@ public class DeleteSoundDialogTest {
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.delete)).perform(click());
 
-		onView(withText(toBeDeletedSoundName)).perform(click());
-		onView(withContentDescription("Done")).perform(click());
+		onRVAtPosition(1)
+				.performCheckItem();
 
-		onView(withText(R.string.dialog_confirm_delete_sound_title)).inRoot(isDialog())
+		onView(withContentDescription(R.string.done)).perform(click());
+
+		onView(withText(UiTestUtils.getResources().getQuantityString(R.plurals.delete_sounds, 1)))
+				.inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
 		onView(withText(R.string.dialog_confirm_delete_sound_message)).inRoot(isDialog())
@@ -112,10 +117,13 @@ public class DeleteSoundDialogTest {
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.delete)).perform(click());
 
-		onView(withText(toBeDeletedSoundName)).perform(click());
-		onView(withContentDescription("Done")).perform(click());
+		onRVAtPosition(1)
+				.performCheckItem();
 
-		onView(withText(R.string.dialog_confirm_delete_sound_title)).inRoot(isDialog())
+		onView(withContentDescription(R.string.done)).perform(click());
+
+		onView(withText(UiTestUtils.getResources().getQuantityString(R.plurals.delete_sounds, 1)))
+				.inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
 		onView(withText(R.string.dialog_confirm_delete)).inRoot(isDialog())
@@ -134,7 +142,7 @@ public class DeleteSoundDialogTest {
 	}
 
 	private void createProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 
 		Sprite sprite = new SingleSprite("testSprite");
 		project.getDefaultScene().addSprite(sprite);
@@ -142,16 +150,16 @@ public class DeleteSoundDialogTest {
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().setCurrentSprite(sprite);
 
-		File soundFile = UiTestUtils.saveFileToProject(
+		File soundFile = FileTestUtils.saveFileToProject(
 				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "longsound.mp3",
-				org.catrobat.catroid.test.R.raw.longsound, InstrumentationRegistry.getTargetContext(),
-				UiTestUtils.FileTypes.SOUND
+				org.catrobat.catroid.test.R.raw.longsound, InstrumentationRegistry.getContext(),
+				FileTestUtils.FileTypes.SOUND
 		);
 
-		File soundFile2 = UiTestUtils.saveFileToProject(
+		File soundFile2 = FileTestUtils.saveFileToProject(
 				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "testsoundui.mp3",
-				org.catrobat.catroid.test.R.raw.testsoundui, InstrumentationRegistry.getTargetContext(),
-				UiTestUtils.FileTypes.SOUND
+				org.catrobat.catroid.test.R.raw.testsoundui, InstrumentationRegistry.getContext(),
+				FileTestUtils.FileTypes.SOUND
 		);
 
 		List<SoundInfo> soundInfoList = ProjectManager.getInstance().getCurrentSprite().getSoundList();

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/DeleteSpriteDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/DeleteSpriteDialogTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.uiespresso.ui.dialog;
 
+import android.content.Intent;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -32,8 +33,11 @@ import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.ui.ProjectActivity;
+import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
+import org.catrobat.catroid.uiespresso.util.actions.CustomActions;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
 import org.junit.Before;
 import org.junit.Rule;
@@ -48,10 +52,12 @@ import static android.support.test.espresso.assertion.ViewAssertions.doesNotExis
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.RootMatchers.isDialog;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
+import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRVAtPosition;
 import static org.hamcrest.Matchers.allOf;
 
 @RunWith(AndroidJUnit4.class)
@@ -66,7 +72,9 @@ public class DeleteSpriteDialogTest {
 	@Before
 	public void setUp() throws Exception {
 		createProject("DeleteSpriteDialogTest");
-		baseActivityTestRule.launchActivity(null);
+		Intent intent = new Intent();
+		intent.putExtra(ProjectActivity.EXTRA_FRAGMENT_POSITION, ProjectActivity.FRAGMENT_SPRITES);
+		baseActivityTestRule.launchActivity(intent);
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class})
@@ -75,13 +83,16 @@ public class DeleteSpriteDialogTest {
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.delete)).perform(click());
 
-		onView(withText(toBeDeletedSpriteName)).perform(click());
-		onView(withContentDescription("Done")).perform(click());
+		onRVAtPosition(2)
+				.performCheckItem();
 
-		onView(withText(R.string.dialog_confirm_delete_object_title)).inRoot(isDialog())
+		onView(withContentDescription(R.string.done)).perform(click());
+
+		onView(withText(UiTestUtils.getResources().getQuantityString(R.plurals.delete_sprites, 1)))
+				.inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
-		onView(withText(R.string.dialog_confirm_delete_object_message)).inRoot(isDialog())
+		onView(withText(R.string.dialog_confirm_delete)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
 		onView(allOf(withId(android.R.id.button1), withText(R.string.yes)))
@@ -92,6 +103,7 @@ public class DeleteSpriteDialogTest {
 		onView(allOf(withId(android.R.id.button1), withText(R.string.yes)))
 				.perform(click());
 
+		onView(isRoot()).perform(CustomActions.wait(5000));
 		onView(withText(toBeDeletedSpriteName))
 				.check(doesNotExist());
 	}
@@ -102,13 +114,16 @@ public class DeleteSpriteDialogTest {
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.delete)).perform(click());
 
-		onView(withText(toBeDeletedSpriteName)).perform(click());
-		onView(withContentDescription("Done")).perform(click());
+		onRVAtPosition(2)
+				.performCheckItem();
 
-		onView(withText(R.string.dialog_confirm_delete_object_title)).inRoot(isDialog())
+		onView(withContentDescription(R.string.done)).perform(click());
+
+		onView(withText(UiTestUtils.getResources().getQuantityString(R.plurals.delete_sprites, 1)))
+				.inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
-		onView(withText(R.string.dialog_confirm_delete_object_message)).inRoot(isDialog())
+		onView(withText(R.string.dialog_confirm_delete)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
 		onView(allOf(withId(android.R.id.button1), withText(R.string.yes)))
@@ -124,7 +139,7 @@ public class DeleteSpriteDialogTest {
 	}
 
 	private void createProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 
 		Sprite firstSprite = new SingleSprite("firstSprite");
 		Sprite secondSprite = new SingleSprite(toBeDeletedSpriteName);
@@ -133,6 +148,6 @@ public class DeleteSpriteDialogTest {
 		project.getDefaultScene().addSprite(secondSprite);
 
 		ProjectManager.getInstance().setProject(project);
-		ProjectManager.getInstance().setCurrentSprite(firstSprite);
+		ProjectManager.getInstance().setCurrentScene(project.getDefaultScene());
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/FormulaEditorComputeDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/FormulaEditorComputeDialogTest.java
@@ -22,6 +22,8 @@
  */
 package org.catrobat.catroid.uiespresso.ui.dialog;
 
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.ViewAction;
 import android.support.test.espresso.action.CoordinatesProvider;
 import android.support.test.espresso.action.GeneralClickAction;
@@ -69,7 +71,11 @@ public class FormulaEditorComputeDialogTest {
 	@Before
 	public void setUp() throws Exception {
 		createProject("formulaEditorComputeDialogTest");
-		baseActivityTestRule.launchActivity(null);
+
+		Intent intent = new Intent();
+		intent.putExtra(SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
+
+		baseActivityTestRule.launchActivity(intent);
 	}
 
 	private void openComputeDialog() {
@@ -127,7 +133,7 @@ public class FormulaEditorComputeDialogTest {
 	}
 
 	public Project createProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		Sprite sprite = new Sprite("testSprite");
 		Script script = new StartScript();
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/RenameSpriteDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/RenameSpriteDialogTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.uiespresso.ui.dialog;
 
+import android.content.Intent;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -55,6 +56,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withContentDesc
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
+import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRVAtPosition;
 import static org.hamcrest.Matchers.allOf;
 
 @RunWith(AndroidJUnit4.class)
@@ -69,7 +71,9 @@ public class RenameSpriteDialogTest {
 	@Before
 	public void setUp() throws Exception {
 		createProject("renameSpriteDialogTest");
-		baseActivityTestRule.launchActivity(null);
+		Intent intent = new Intent();
+		intent.putExtra(ProjectActivity.EXTRA_FRAGMENT_POSITION, ProjectActivity.FRAGMENT_SPRITES);
+		baseActivityTestRule.launchActivity(intent);
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class})
@@ -77,7 +81,7 @@ public class RenameSpriteDialogTest {
 	@Flaky
 	public void renameSpriteDialogTest() {
 		String newSpriteName = "renamedSprite";
-		renameFirstSpriteTo(newSpriteName);
+		renameSpriteTo(newSpriteName);
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class})
@@ -85,15 +89,17 @@ public class RenameSpriteDialogTest {
 	@Flaky
 	public void renameSpriteSwitchCaseDialogTest() {
 		String newSpriteName = "SeConDspRite";
-		renameFirstSpriteTo(newSpriteName);
+		renameSpriteTo(newSpriteName);
 	}
 
-	private void renameFirstSpriteTo(String newSpriteName) {
+	private void renameSpriteTo(String newSpriteName) {
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.rename)).perform(click());
 
-		onView(withText(oldSpriteName)).perform(click());
-		onView(withContentDescription("Done")).perform(click());
+		onRVAtPosition(2)
+				.performCheckItem();
+
+		onView(withContentDescription(R.string.done)).perform(click());
 
 		onView(withText(R.string.rename_sprite_dialog)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
@@ -112,7 +118,7 @@ public class RenameSpriteDialogTest {
 	}
 
 	private void createProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 
 		Sprite firstSprite = new SingleSprite("firstSprite");
 		Sprite secondSprite = new SingleSprite(oldSpriteName);
@@ -121,6 +127,6 @@ public class RenameSpriteDialogTest {
 		project.getDefaultScene().addSprite(secondSprite);
 
 		ProjectManager.getInstance().setProject(project);
-		ProjectManager.getInstance().setCurrentSprite(firstSprite);
+		ProjectManager.getInstance().setCurrentScene(project.getDefaultScene());
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CopyLookFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CopyLookFragmentTest.java
@@ -33,12 +33,11 @@ import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
-import org.catrobat.catroid.ui.ScriptActivity;
-import org.catrobat.catroid.uiespresso.pocketmusic.RecyclerViewMatcher;
+import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.FileTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
-import org.catrobat.catroid.uitest.util.UiTestUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,12 +55,14 @@ import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
+import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRVAtPosition;
+
 @RunWith(AndroidJUnit4.class)
 public class CopyLookFragmentTest {
 
 	@Rule
-	public BaseActivityInstrumentationRule<ScriptActivity> baseActivityTestRule = new
-			BaseActivityInstrumentationRule<>(ScriptActivity.class, true, false);
+	public BaseActivityInstrumentationRule<SpriteActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(SpriteActivity.class, true, false);
 
 	private String toBeCopiedLookName = "testLook";
 
@@ -70,7 +71,7 @@ public class CopyLookFragmentTest {
 		createProject("copyLookFragmentTest");
 
 		Intent intent = new Intent();
-		intent.putExtra(ScriptActivity.EXTRA_FRAGMENT_POSITION, ScriptActivity.FRAGMENT_LOOKS);
+		intent.putExtra(SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_LOOKS);
 
 		baseActivityTestRule.launchActivity(intent);
 	}
@@ -81,9 +82,8 @@ public class CopyLookFragmentTest {
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.copy)).perform(click());
 
-		onView(new RecyclerViewMatcher(R.id.recycler_view)
-				.atPositionOnView(0, R.id.list_item_checkbox))
-				.perform(click());
+		onRVAtPosition(0)
+			.performCheckItem();
 
 		onView(withContentDescription("Done")).perform(click());
 
@@ -95,7 +95,7 @@ public class CopyLookFragmentTest {
 	}
 
 	private void createProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 
 		Sprite sprite = new SingleSprite("testSprite");
 		project.getDefaultScene().addSprite(sprite);
@@ -103,18 +103,16 @@ public class CopyLookFragmentTest {
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().setCurrentSprite(sprite);
 
-		File imageFile = UiTestUtils.saveFileToProject(
+		File imageFile = FileTestUtils.saveFileToProject(
 				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "catroid_sunglasses.png",
-				org.catrobat.catroid.test.R.drawable.catroid_banzai, InstrumentationRegistry.getTargetContext(),
-				UiTestUtils.FileTypes.IMAGE
+				org.catrobat.catroid.test.R.drawable.catroid_banzai, InstrumentationRegistry.getContext(),
+				FileTestUtils.FileTypes.IMAGE
 		);
 
-		List<LookData> lookDataList = ProjectManager.getInstance().getCurrentSprite().getLookDataList();
+		List<LookData> lookDataList = ProjectManager.getInstance().getCurrentSprite().getLookList();
 		LookData lookData = new LookData();
-		lookData.setLookFilename(imageFile.getName());
-		lookData.setLookName(toBeCopiedLookName);
+		lookData.setFileName(imageFile.getName());
+		lookData.setName(toBeCopiedLookName);
 		lookDataList.add(lookData);
-		ProjectManager.getInstance().getFileChecksumContainer()
-				.addChecksum(lookData.getChecksum(), lookData.getAbsolutePath());
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CopyLookFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CopyLookFragmentTest.java
@@ -1,0 +1,120 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.fragment;
+
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.LookData;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.SingleSprite;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.ui.ScriptActivity;
+import org.catrobat.catroid.uiespresso.pocketmusic.RecyclerViewMatcher;
+import org.catrobat.catroid.uiespresso.testsuites.Cat;
+import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
+import org.catrobat.catroid.uitest.util.UiTestUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.List;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+@RunWith(AndroidJUnit4.class)
+public class CopyLookFragmentTest {
+
+	@Rule
+	public BaseActivityInstrumentationRule<ScriptActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(ScriptActivity.class, true, false);
+
+	private String toBeCopiedLookName = "testLook";
+
+	@Before
+	public void setUp() throws Exception {
+		createProject("copyLookFragmentTest");
+
+		Intent intent = new Intent();
+		intent.putExtra(ScriptActivity.EXTRA_FRAGMENT_POSITION, ScriptActivity.FRAGMENT_LOOKS);
+
+		baseActivityTestRule.launchActivity(intent);
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void copyLookFragmentTest() {
+		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
+		onView(withText(R.string.copy)).perform(click());
+
+		onView(new RecyclerViewMatcher(R.id.recycler_view)
+				.atPositionOnView(0, R.id.list_item_checkbox))
+				.perform(click());
+
+		onView(withContentDescription("Done")).perform(click());
+
+		onView(withText(toBeCopiedLookName))
+				.check(matches(isDisplayed()));
+
+		onView(withText(toBeCopiedLookName + " (1)"))
+				.check(matches(isDisplayed()));
+	}
+
+	private void createProject(String projectName) {
+		Project project = new Project(null, projectName);
+
+		Sprite sprite = new SingleSprite("testSprite");
+		project.getDefaultScene().addSprite(sprite);
+
+		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite);
+
+		File imageFile = UiTestUtils.saveFileToProject(
+				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "catroid_sunglasses.png",
+				org.catrobat.catroid.test.R.drawable.catroid_banzai, InstrumentationRegistry.getTargetContext(),
+				UiTestUtils.FileTypes.IMAGE
+		);
+
+		List<LookData> lookDataList = ProjectManager.getInstance().getCurrentSprite().getLookDataList();
+		LookData lookData = new LookData();
+		lookData.setLookFilename(imageFile.getName());
+		lookData.setLookName(toBeCopiedLookName);
+		lookDataList.add(lookData);
+		ProjectManager.getInstance().getFileChecksumContainer()
+				.addChecksum(lookData.getChecksum(), lookData.getAbsolutePath());
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CopySoundFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CopySoundFragmentTest.java
@@ -33,12 +33,11 @@ import org.catrobat.catroid.common.SoundInfo;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
-import org.catrobat.catroid.ui.ScriptActivity;
-import org.catrobat.catroid.uiespresso.pocketmusic.RecyclerViewMatcher;
+import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.FileTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
-import org.catrobat.catroid.uitest.util.UiTestUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,12 +55,14 @@ import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
+import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRVAtPosition;
+
 @RunWith(AndroidJUnit4.class)
 public class CopySoundFragmentTest {
 
 	@Rule
-	public BaseActivityInstrumentationRule<ScriptActivity> baseActivityTestRule = new
-			BaseActivityInstrumentationRule<>(ScriptActivity.class, true, false);
+	public BaseActivityInstrumentationRule<SpriteActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(SpriteActivity.class, true, false);
 
 	private String toBeCopiedSoundName = "testSound";
 
@@ -70,7 +71,7 @@ public class CopySoundFragmentTest {
 		createProject("copySoundFragmentTest");
 
 		Intent intent = new Intent();
-		intent.putExtra(ScriptActivity.EXTRA_FRAGMENT_POSITION, ScriptActivity.FRAGMENT_SOUNDS);
+		intent.putExtra(SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SOUNDS);
 
 		baseActivityTestRule.launchActivity(intent);
 	}
@@ -81,9 +82,8 @@ public class CopySoundFragmentTest {
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.copy)).perform(click());
 
-		onView(new RecyclerViewMatcher(R.id.recycler_view)
-				.atPositionOnView(0, R.id.list_item_checkbox))
-				.perform(click());
+		onRVAtPosition(0)
+				.performCheckItem();
 
 		onView(withContentDescription("Done")).perform(click());
 
@@ -95,7 +95,7 @@ public class CopySoundFragmentTest {
 	}
 
 	private void createProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 
 		Sprite sprite = new SingleSprite("testSprite");
 		project.getDefaultScene().addSprite(sprite);
@@ -103,18 +103,16 @@ public class CopySoundFragmentTest {
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().setCurrentSprite(sprite);
 
-		File soundFile = UiTestUtils.saveFileToProject(
+		File soundFile = FileTestUtils.saveFileToProject(
 				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "longsound.mp3",
-				org.catrobat.catroid.test.R.raw.longsound, InstrumentationRegistry.getTargetContext(),
-				UiTestUtils.FileTypes.SOUND
+				org.catrobat.catroid.test.R.raw.longsound, InstrumentationRegistry.getContext(),
+				FileTestUtils.FileTypes.SOUND
 		);
 
 		List<SoundInfo> soundInfoList = ProjectManager.getInstance().getCurrentSprite().getSoundList();
 		SoundInfo soundInfo = new SoundInfo();
-		soundInfo.setSoundFileName(soundFile.getName());
-		soundInfo.setTitle(toBeCopiedSoundName);
+		soundInfo.setFileName(soundFile.getName());
+		soundInfo.setName(toBeCopiedSoundName);
 		soundInfoList.add(soundInfo);
-		ProjectManager.getInstance().getFileChecksumContainer()
-				.addChecksum(soundInfo.getChecksum(), soundInfo.getAbsolutePath());
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CopySoundFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CopySoundFragmentTest.java
@@ -1,0 +1,120 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.fragment;
+
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.SoundInfo;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.SingleSprite;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.ui.ScriptActivity;
+import org.catrobat.catroid.uiespresso.pocketmusic.RecyclerViewMatcher;
+import org.catrobat.catroid.uiespresso.testsuites.Cat;
+import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
+import org.catrobat.catroid.uitest.util.UiTestUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.List;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+@RunWith(AndroidJUnit4.class)
+public class CopySoundFragmentTest {
+
+	@Rule
+	public BaseActivityInstrumentationRule<ScriptActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(ScriptActivity.class, true, false);
+
+	private String toBeCopiedSoundName = "testSound";
+
+	@Before
+	public void setUp() throws Exception {
+		createProject("copySoundFragmentTest");
+
+		Intent intent = new Intent();
+		intent.putExtra(ScriptActivity.EXTRA_FRAGMENT_POSITION, ScriptActivity.FRAGMENT_SOUNDS);
+
+		baseActivityTestRule.launchActivity(intent);
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void copySoundFragmentTest() {
+		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
+		onView(withText(R.string.copy)).perform(click());
+
+		onView(new RecyclerViewMatcher(R.id.recycler_view)
+				.atPositionOnView(0, R.id.list_item_checkbox))
+				.perform(click());
+
+		onView(withContentDescription("Done")).perform(click());
+
+		onView(withText(toBeCopiedSoundName))
+				.check(matches(isDisplayed()));
+
+		onView(withText(toBeCopiedSoundName + " (1)"))
+				.check(matches(isDisplayed()));
+	}
+
+	private void createProject(String projectName) {
+		Project project = new Project(null, projectName);
+
+		Sprite sprite = new SingleSprite("testSprite");
+		project.getDefaultScene().addSprite(sprite);
+
+		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite);
+
+		File soundFile = UiTestUtils.saveFileToProject(
+				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "longsound.mp3",
+				org.catrobat.catroid.test.R.raw.longsound, InstrumentationRegistry.getTargetContext(),
+				UiTestUtils.FileTypes.SOUND
+		);
+
+		List<SoundInfo> soundInfoList = ProjectManager.getInstance().getCurrentSprite().getSoundList();
+		SoundInfo soundInfo = new SoundInfo();
+		soundInfo.setSoundFileName(soundFile.getName());
+		soundInfo.setTitle(toBeCopiedSoundName);
+		soundInfoList.add(soundInfo);
+		ProjectManager.getInstance().getFileChecksumContainer()
+				.addChecksum(soundInfo.getChecksum(), soundInfo.getAbsolutePath());
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DeleteLookFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DeleteLookFragmentTest.java
@@ -1,0 +1,177 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.fragment;
+
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.LookData;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.SingleSprite;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.ui.ScriptActivity;
+import org.catrobat.catroid.uiespresso.pocketmusic.RecyclerViewMatcher;
+import org.catrobat.catroid.uiespresso.testsuites.Cat;
+import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
+import org.catrobat.catroid.uitest.util.UiTestUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.List;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.RootMatchers.isDialog;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static org.hamcrest.Matchers.allOf;
+
+@RunWith(AndroidJUnit4.class)
+public class DeleteLookFragmentTest {
+
+	@Rule
+	public BaseActivityInstrumentationRule<ScriptActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(ScriptActivity.class, true, false);
+
+	private String toBeDeletedLookName = "testLook2";
+
+	@Before
+	public void setUp() throws Exception {
+		createProject("deleteLookFragmentTest");
+
+		Intent intent = new Intent();
+		intent.putExtra(ScriptActivity.EXTRA_FRAGMENT_POSITION, ScriptActivity.FRAGMENT_LOOKS);
+
+		baseActivityTestRule.launchActivity(intent);
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void deleteLookFragmentTest() {
+		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
+		onView(withText(R.string.delete)).perform(click());
+
+		onView(new RecyclerViewMatcher(R.id.recycler_view).atPositionOnView(1, R.id.list_item_checkbox)).perform(click());
+
+		onView(withContentDescription("Done")).perform(click());
+
+		onView(withText(org.catrobat.catroid.uiespresso.util.UiTestUtils.getResources().
+				getQuantityString(R.plurals.delete_looks, 1))).inRoot(isDialog())
+				.check(matches(isDisplayed()));
+
+		onView(withText(R.string.dialog_confirm_delete_look_message)).inRoot(isDialog())
+				.check(matches(isDisplayed()));
+
+		onView(allOf(withId(android.R.id.button1), withText(R.string.yes)))
+				.check(matches(isDisplayed()));
+		onView(allOf(withId(android.R.id.button2), withText(R.string.no)))
+				.check(matches(isDisplayed()));
+
+		onView(allOf(withId(android.R.id.button1), withText(R.string.yes)))
+				.perform(click());
+
+		onView(withText(toBeDeletedLookName))
+				.check(doesNotExist());
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void cancelDeleteLookFragmentTest() {
+		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
+		onView(withText(R.string.delete)).perform(click());
+
+		onView(new RecyclerViewMatcher(R.id.recycler_view).atPositionOnView(1, R.id.list_item_checkbox)).perform(click());
+
+		onView(withContentDescription("Done")).perform(click());
+
+		onView(withText(org.catrobat.catroid.uiespresso.util.UiTestUtils.getResources().
+				getQuantityString(R.plurals.delete_looks, 1))).inRoot(isDialog())
+				.check(matches(isDisplayed()));
+
+		onView(withText(R.string.dialog_confirm_delete_look_message)).inRoot(isDialog())
+				.check(matches(isDisplayed()));
+
+		onView(allOf(withId(android.R.id.button1), withText(R.string.yes)))
+				.check(matches(isDisplayed()));
+		onView(allOf(withId(android.R.id.button2), withText(R.string.no)))
+				.check(matches(isDisplayed()));
+
+		onView(allOf(withId(android.R.id.button2), withText(R.string.no)))
+				.perform(click());
+
+		onView(withText(toBeDeletedLookName))
+				.check(matches(isDisplayed()));
+	}
+
+	private void createProject(String projectName) {
+		Project project = new Project(null, projectName);
+
+		Sprite sprite = new SingleSprite("testSprite");
+		project.getDefaultScene().addSprite(sprite);
+
+		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite);
+
+		File imageFile = UiTestUtils.saveFileToProject(
+				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "catroid_sunglasses.png",
+				org.catrobat.catroid.test.R.drawable.catroid_banzai, InstrumentationRegistry.getTargetContext(),
+				UiTestUtils.FileTypes.IMAGE
+		);
+
+		File imageFile2 = UiTestUtils.saveFileToProject(
+				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "catroid_banzai.png",
+				org.catrobat.catroid.test.R.drawable.catroid_banzai, InstrumentationRegistry.getTargetContext(),
+				UiTestUtils.FileTypes.IMAGE
+		);
+
+		List<LookData> lookDataList = ProjectManager.getInstance().getCurrentSprite().getLookDataList();
+		LookData lookData = new LookData();
+		lookData.setLookFilename(imageFile.getName());
+		lookData.setLookName("testLook1");
+		lookDataList.add(lookData);
+		ProjectManager.getInstance().getFileChecksumContainer()
+				.addChecksum(lookData.getChecksum(), lookData.getAbsolutePath());
+
+		LookData lookData2 = new LookData();
+		lookData2.setLookFilename(imageFile2.getName());
+		lookData2.setLookName(toBeDeletedLookName);
+		lookDataList.add(lookData2);
+		ProjectManager.getInstance().getFileChecksumContainer()
+				.addChecksum(lookData2.getChecksum(), lookData2.getAbsolutePath());
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DeleteLookFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DeleteLookFragmentTest.java
@@ -33,12 +33,12 @@ import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
-import org.catrobat.catroid.ui.ScriptActivity;
-import org.catrobat.catroid.uiespresso.pocketmusic.RecyclerViewMatcher;
+import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.FileTestUtils;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
-import org.catrobat.catroid.uitest.util.UiTestUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,14 +59,15 @@ import static android.support.test.espresso.matcher.ViewMatchers.withContentDesc
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
+import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRVAtPosition;
 import static org.hamcrest.Matchers.allOf;
 
 @RunWith(AndroidJUnit4.class)
 public class DeleteLookFragmentTest {
 
 	@Rule
-	public BaseActivityInstrumentationRule<ScriptActivity> baseActivityTestRule = new
-			BaseActivityInstrumentationRule<>(ScriptActivity.class, true, false);
+	public BaseActivityInstrumentationRule<SpriteActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(SpriteActivity.class, true, false);
 
 	private String toBeDeletedLookName = "testLook2";
 
@@ -75,7 +76,7 @@ public class DeleteLookFragmentTest {
 		createProject("deleteLookFragmentTest");
 
 		Intent intent = new Intent();
-		intent.putExtra(ScriptActivity.EXTRA_FRAGMENT_POSITION, ScriptActivity.FRAGMENT_LOOKS);
+		intent.putExtra(SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_LOOKS);
 
 		baseActivityTestRule.launchActivity(intent);
 	}
@@ -86,19 +87,18 @@ public class DeleteLookFragmentTest {
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.delete)).perform(click());
 
-		onView(new RecyclerViewMatcher(R.id.recycler_view).atPositionOnView(1, R.id.list_item_checkbox)).perform(click());
+		onRVAtPosition(1)
+				.performCheckItem();
 
 		onView(withContentDescription("Done")).perform(click());
 
-		onView(withText(org.catrobat.catroid.uiespresso.util.UiTestUtils.getResources().
-				getQuantityString(R.plurals.delete_looks, 1))).inRoot(isDialog())
+		onView(withText(UiTestUtils.getResources().getQuantityString(R.plurals.delete_looks, 1)))
+				.inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
 		onView(withText(R.string.dialog_confirm_delete_look_message)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
-		onView(allOf(withId(android.R.id.button1), withText(R.string.yes)))
-				.check(matches(isDisplayed()));
 		onView(allOf(withId(android.R.id.button2), withText(R.string.no)))
 				.check(matches(isDisplayed()));
 
@@ -115,20 +115,19 @@ public class DeleteLookFragmentTest {
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.delete)).perform(click());
 
-		onView(new RecyclerViewMatcher(R.id.recycler_view).atPositionOnView(1, R.id.list_item_checkbox)).perform(click());
+		onRVAtPosition(1)
+				.performCheckItem();
 
 		onView(withContentDescription("Done")).perform(click());
 
-		onView(withText(org.catrobat.catroid.uiespresso.util.UiTestUtils.getResources().
-				getQuantityString(R.plurals.delete_looks, 1))).inRoot(isDialog())
+		onView(withText(UiTestUtils.getResources().getQuantityString(R.plurals.delete_looks, 1)))
+				.inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
 		onView(withText(R.string.dialog_confirm_delete_look_message)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
 		onView(allOf(withId(android.R.id.button1), withText(R.string.yes)))
-				.check(matches(isDisplayed()));
-		onView(allOf(withId(android.R.id.button2), withText(R.string.no)))
 				.check(matches(isDisplayed()));
 
 		onView(allOf(withId(android.R.id.button2), withText(R.string.no)))
@@ -139,7 +138,7 @@ public class DeleteLookFragmentTest {
 	}
 
 	private void createProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 
 		Sprite sprite = new SingleSprite("testSprite");
 		project.getDefaultScene().addSprite(sprite);
@@ -147,31 +146,27 @@ public class DeleteLookFragmentTest {
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().setCurrentSprite(sprite);
 
-		File imageFile = UiTestUtils.saveFileToProject(
+		File imageFile = FileTestUtils.saveFileToProject(
 				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "catroid_sunglasses.png",
-				org.catrobat.catroid.test.R.drawable.catroid_banzai, InstrumentationRegistry.getTargetContext(),
-				UiTestUtils.FileTypes.IMAGE
+				org.catrobat.catroid.test.R.drawable.catroid_banzai, InstrumentationRegistry.getContext(),
+				FileTestUtils.FileTypes.IMAGE
 		);
 
-		File imageFile2 = UiTestUtils.saveFileToProject(
+		File imageFile2 = FileTestUtils.saveFileToProject(
 				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "catroid_banzai.png",
-				org.catrobat.catroid.test.R.drawable.catroid_banzai, InstrumentationRegistry.getTargetContext(),
-				UiTestUtils.FileTypes.IMAGE
+				org.catrobat.catroid.test.R.drawable.catroid_banzai, InstrumentationRegistry.getContext(),
+				FileTestUtils.FileTypes.IMAGE
 		);
 
-		List<LookData> lookDataList = ProjectManager.getInstance().getCurrentSprite().getLookDataList();
+		List<LookData> lookDataList = ProjectManager.getInstance().getCurrentSprite().getLookList();
 		LookData lookData = new LookData();
-		lookData.setLookFilename(imageFile.getName());
-		lookData.setLookName("testLook1");
+		lookData.setFileName(imageFile.getName());
+		lookData.setName("testLook1");
 		lookDataList.add(lookData);
-		ProjectManager.getInstance().getFileChecksumContainer()
-				.addChecksum(lookData.getChecksum(), lookData.getAbsolutePath());
 
 		LookData lookData2 = new LookData();
-		lookData2.setLookFilename(imageFile2.getName());
-		lookData2.setLookName(toBeDeletedLookName);
+		lookData2.setFileName(imageFile2.getName());
+		lookData2.setName(toBeDeletedLookName);
 		lookDataList.add(lookData2);
-		ProjectManager.getInstance().getFileChecksumContainer()
-				.addChecksum(lookData2.getChecksum(), lookData2.getAbsolutePath());
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DeleteSoundFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DeleteSoundFragmentTest.java
@@ -1,0 +1,177 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.fragment;
+
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.SoundInfo;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.SingleSprite;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.ui.ScriptActivity;
+import org.catrobat.catroid.uiespresso.pocketmusic.RecyclerViewMatcher;
+import org.catrobat.catroid.uiespresso.testsuites.Cat;
+import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
+import org.catrobat.catroid.uitest.util.UiTestUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.List;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.RootMatchers.isDialog;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static org.hamcrest.Matchers.allOf;
+
+@RunWith(AndroidJUnit4.class)
+public class DeleteSoundFragmentTest {
+
+	@Rule
+	public BaseActivityInstrumentationRule<ScriptActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(ScriptActivity.class, true, false);
+
+	private String toBeDeletedSoundName = "testSound2";
+
+	@Before
+	public void setUp() throws Exception {
+		createProject("deleteSoundFragmentTest");
+
+		Intent intent = new Intent();
+		intent.putExtra(ScriptActivity.EXTRA_FRAGMENT_POSITION, ScriptActivity.FRAGMENT_SOUNDS);
+
+		baseActivityTestRule.launchActivity(intent);
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void deleteSoundFragmentTest() {
+		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
+		onView(withText(R.string.delete)).perform(click());
+
+		onView(new RecyclerViewMatcher(R.id.recycler_view).atPositionOnView(1, R.id.list_item_checkbox)).perform(click());
+
+		onView(withContentDescription("Done")).perform(click());
+
+		onView(withText(org.catrobat.catroid.uiespresso.util.UiTestUtils.getResources().getQuantityString(R.plurals
+				.delete_sounds, 1))).inRoot(isDialog())
+				.check(matches(isDisplayed()));
+
+		onView(withText(R.string.dialog_confirm_delete_sound_message)).inRoot(isDialog())
+				.check(matches(isDisplayed()));
+
+		onView(allOf(withId(android.R.id.button1), withText(R.string.yes)))
+				.check(matches(isDisplayed()));
+		onView(allOf(withId(android.R.id.button2), withText(R.string.no)))
+				.check(matches(isDisplayed()));
+
+		onView(allOf(withId(android.R.id.button1), withText(R.string.yes)))
+				.perform(click());
+
+		onView(withText(toBeDeletedSoundName))
+				.check(doesNotExist());
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void cancelDeleteSoundFragmentTest() {
+		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
+		onView(withText(R.string.delete)).perform(click());
+
+		onView(new RecyclerViewMatcher(R.id.recycler_view).atPositionOnView(1, R.id.list_item_checkbox)).perform(click());
+
+		onView(withContentDescription("Done")).perform(click());
+
+		onView(withText(org.catrobat.catroid.uiespresso.util.UiTestUtils.getResources().getQuantityString(R.plurals
+				.delete_sounds, 1))).inRoot(isDialog())
+				.check(matches(isDisplayed()));
+
+		onView(withText(R.string.dialog_confirm_delete_sound_message)).inRoot(isDialog())
+				.check(matches(isDisplayed()));
+
+		onView(allOf(withId(android.R.id.button1), withText(R.string.yes)))
+				.check(matches(isDisplayed()));
+		onView(allOf(withId(android.R.id.button2), withText(R.string.no)))
+				.check(matches(isDisplayed()));
+
+		onView(allOf(withId(android.R.id.button2), withText(R.string.no)))
+				.perform(click());
+
+		onView(withText(toBeDeletedSoundName))
+				.check(matches(isDisplayed()));
+	}
+
+	private void createProject(String projectName) {
+		Project project = new Project(null, projectName);
+
+		Sprite sprite = new SingleSprite("testSprite");
+		project.getDefaultScene().addSprite(sprite);
+
+		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite);
+
+		File soundFile = UiTestUtils.saveFileToProject(
+				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "longsound.mp3",
+				org.catrobat.catroid.test.R.raw.longsound, InstrumentationRegistry.getTargetContext(),
+				UiTestUtils.FileTypes.SOUND
+		);
+
+		File soundFile2 = UiTestUtils.saveFileToProject(
+				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "testsoundui.mp3",
+				org.catrobat.catroid.test.R.raw.testsoundui, InstrumentationRegistry.getTargetContext(),
+				UiTestUtils.FileTypes.SOUND
+		);
+
+		List<SoundInfo> soundInfoList = ProjectManager.getInstance().getCurrentSprite().getSoundList();
+		SoundInfo soundInfo = new SoundInfo();
+		soundInfo.setSoundFileName(soundFile.getName());
+		soundInfo.setTitle("testSound1");
+		soundInfoList.add(soundInfo);
+		ProjectManager.getInstance().getFileChecksumContainer()
+				.addChecksum(soundInfo.getChecksum(), soundInfo.getAbsolutePath());
+
+		SoundInfo soundInfo2 = new SoundInfo();
+		soundInfo2.setSoundFileName(soundFile2.getName());
+		soundInfo2.setTitle(toBeDeletedSoundName);
+		soundInfoList.add(soundInfo2);
+		ProjectManager.getInstance().getFileChecksumContainer()
+				.addChecksum(soundInfo2.getChecksum(), soundInfo2.getAbsolutePath());
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DeleteSoundFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DeleteSoundFragmentTest.java
@@ -33,12 +33,12 @@ import org.catrobat.catroid.common.SoundInfo;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
-import org.catrobat.catroid.ui.ScriptActivity;
-import org.catrobat.catroid.uiespresso.pocketmusic.RecyclerViewMatcher;
+import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.FileTestUtils;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
-import org.catrobat.catroid.uitest.util.UiTestUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,14 +59,15 @@ import static android.support.test.espresso.matcher.ViewMatchers.withContentDesc
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
+import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRVAtPosition;
 import static org.hamcrest.Matchers.allOf;
 
 @RunWith(AndroidJUnit4.class)
 public class DeleteSoundFragmentTest {
 
 	@Rule
-	public BaseActivityInstrumentationRule<ScriptActivity> baseActivityTestRule = new
-			BaseActivityInstrumentationRule<>(ScriptActivity.class, true, false);
+	public BaseActivityInstrumentationRule<SpriteActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(SpriteActivity.class, true, false);
 
 	private String toBeDeletedSoundName = "testSound2";
 
@@ -75,7 +76,7 @@ public class DeleteSoundFragmentTest {
 		createProject("deleteSoundFragmentTest");
 
 		Intent intent = new Intent();
-		intent.putExtra(ScriptActivity.EXTRA_FRAGMENT_POSITION, ScriptActivity.FRAGMENT_SOUNDS);
+		intent.putExtra(SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SOUNDS);
 
 		baseActivityTestRule.launchActivity(intent);
 	}
@@ -86,19 +87,18 @@ public class DeleteSoundFragmentTest {
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.delete)).perform(click());
 
-		onView(new RecyclerViewMatcher(R.id.recycler_view).atPositionOnView(1, R.id.list_item_checkbox)).perform(click());
+		onRVAtPosition(1)
+				.performCheckItem();
 
 		onView(withContentDescription("Done")).perform(click());
 
-		onView(withText(org.catrobat.catroid.uiespresso.util.UiTestUtils.getResources().getQuantityString(R.plurals
-				.delete_sounds, 1))).inRoot(isDialog())
+		onView(withText(UiTestUtils.getResources().getQuantityString(R.plurals.delete_sounds, 1)))
+				.inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
 		onView(withText(R.string.dialog_confirm_delete_sound_message)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
-		onView(allOf(withId(android.R.id.button1), withText(R.string.yes)))
-				.check(matches(isDisplayed()));
 		onView(allOf(withId(android.R.id.button2), withText(R.string.no)))
 				.check(matches(isDisplayed()));
 
@@ -115,20 +115,19 @@ public class DeleteSoundFragmentTest {
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.delete)).perform(click());
 
-		onView(new RecyclerViewMatcher(R.id.recycler_view).atPositionOnView(1, R.id.list_item_checkbox)).perform(click());
+		onRVAtPosition(1)
+				.performCheckItem();
 
 		onView(withContentDescription("Done")).perform(click());
 
-		onView(withText(org.catrobat.catroid.uiespresso.util.UiTestUtils.getResources().getQuantityString(R.plurals
-				.delete_sounds, 1))).inRoot(isDialog())
+		onView(withText(UiTestUtils.getResources().getQuantityString(R.plurals.delete_sounds, 1)))
+				.inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
 		onView(withText(R.string.dialog_confirm_delete_sound_message)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
 		onView(allOf(withId(android.R.id.button1), withText(R.string.yes)))
-				.check(matches(isDisplayed()));
-		onView(allOf(withId(android.R.id.button2), withText(R.string.no)))
 				.check(matches(isDisplayed()));
 
 		onView(allOf(withId(android.R.id.button2), withText(R.string.no)))
@@ -139,7 +138,7 @@ public class DeleteSoundFragmentTest {
 	}
 
 	private void createProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 
 		Sprite sprite = new SingleSprite("testSprite");
 		project.getDefaultScene().addSprite(sprite);
@@ -147,31 +146,27 @@ public class DeleteSoundFragmentTest {
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().setCurrentSprite(sprite);
 
-		File soundFile = UiTestUtils.saveFileToProject(
+		File soundFile = FileTestUtils.saveFileToProject(
 				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "longsound.mp3",
-				org.catrobat.catroid.test.R.raw.longsound, InstrumentationRegistry.getTargetContext(),
-				UiTestUtils.FileTypes.SOUND
+				org.catrobat.catroid.test.R.raw.longsound, InstrumentationRegistry.getContext(),
+				FileTestUtils.FileTypes.SOUND
 		);
 
-		File soundFile2 = UiTestUtils.saveFileToProject(
+		File soundFile2 = FileTestUtils.saveFileToProject(
 				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "testsoundui.mp3",
-				org.catrobat.catroid.test.R.raw.testsoundui, InstrumentationRegistry.getTargetContext(),
-				UiTestUtils.FileTypes.SOUND
+				org.catrobat.catroid.test.R.raw.testsoundui, InstrumentationRegistry.getContext(),
+				FileTestUtils.FileTypes.SOUND
 		);
 
 		List<SoundInfo> soundInfoList = ProjectManager.getInstance().getCurrentSprite().getSoundList();
 		SoundInfo soundInfo = new SoundInfo();
-		soundInfo.setSoundFileName(soundFile.getName());
-		soundInfo.setTitle("testSound1");
+		soundInfo.setFileName(soundFile.getName());
+		soundInfo.setName("testSound1");
 		soundInfoList.add(soundInfo);
-		ProjectManager.getInstance().getFileChecksumContainer()
-				.addChecksum(soundInfo.getChecksum(), soundInfo.getAbsolutePath());
 
 		SoundInfo soundInfo2 = new SoundInfo();
-		soundInfo2.setSoundFileName(soundFile2.getName());
-		soundInfo2.setTitle(toBeDeletedSoundName);
+		soundInfo2.setFileName(soundFile2.getName());
+		soundInfo2.setName(toBeDeletedSoundName);
 		soundInfoList.add(soundInfo2);
-		ProjectManager.getInstance().getFileChecksumContainer()
-				.addChecksum(soundInfo2.getChecksum(), soundInfo2.getAbsolutePath());
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameLookFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameLookFragmentTest.java
@@ -1,0 +1,162 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.fragment;
+
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.LookData;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.SingleSprite;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.ui.ScriptActivity;
+import org.catrobat.catroid.uiespresso.pocketmusic.RecyclerViewMatcher;
+import org.catrobat.catroid.uiespresso.testsuites.Cat;
+import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
+import org.catrobat.catroid.uitest.util.UiTestUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.List;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.action.ViewActions.clearText;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.RootMatchers.isDialog;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static org.hamcrest.Matchers.allOf;
+
+@RunWith(AndroidJUnit4.class)
+public class RenameLookFragmentTest {
+
+	@Rule
+	public BaseActivityInstrumentationRule<ScriptActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(ScriptActivity.class, true, false);
+
+	private String oldLookName = "oldLookName";
+	private String newLookName = "newLookName";
+
+	@Before
+	public void setUp() throws Exception {
+		createProject("renameLookFragmentTest");
+
+		Intent intent = new Intent();
+		intent.putExtra(ScriptActivity.EXTRA_FRAGMENT_POSITION, ScriptActivity.FRAGMENT_LOOKS);
+
+		baseActivityTestRule.launchActivity(intent);
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void renameLookFragmentTest() {
+		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
+		onView(withText(R.string.rename)).perform(click());
+
+		onView(new RecyclerViewMatcher(R.id.recycler_view)
+				.atPositionOnView(0, R.id.list_item_checkbox))
+				.perform(click());
+
+		onView(withContentDescription("Done")).perform(click());
+
+		onView(withText(R.string.rename_look_dialog)).inRoot(isDialog())
+				.check(matches(isDisplayed()));
+
+		onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
+				.check(matches(isDisplayed()));
+		onView(allOf(withId(android.R.id.button2), withText(R.string.cancel)))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.edit_text)).perform(clearText(), typeText(newLookName));
+
+		onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
+				.perform(click());
+
+		onView(withText(newLookName)).check(matches(isDisplayed()));
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void cancelRenameLookFragmentTest() {
+		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
+		onView(withText(R.string.rename)).perform(click());
+
+		onView(new RecyclerViewMatcher(R.id.recycler_view)
+				.atPositionOnView(0, R.id.list_item_checkbox))
+				.perform(click());
+
+		onView(withContentDescription("Done")).perform(click());
+
+		onView(withText(R.string.rename_look_dialog)).inRoot(isDialog())
+				.check(matches(isDisplayed()));
+
+		onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
+				.check(matches(isDisplayed()));
+		onView(allOf(withId(android.R.id.button2), withText(R.string.cancel)))
+				.check(matches(isDisplayed()));
+
+		onView(allOf(withId(android.R.id.button2), withText(R.string.cancel)))
+				.perform(click());
+
+		onView(withText(oldLookName)).check(matches(isDisplayed()));
+	}
+
+	private void createProject(String projectName) {
+		Project project = new Project(null, projectName);
+
+		Sprite sprite = new SingleSprite("testSprite");
+		project.getDefaultScene().addSprite(sprite);
+
+		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite);
+
+		File imageFile = UiTestUtils.saveFileToProject(
+				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "catroid_sunglasses.png",
+				org.catrobat.catroid.test.R.drawable.catroid_banzai, InstrumentationRegistry.getTargetContext(),
+				UiTestUtils.FileTypes.IMAGE
+		);
+
+		List<LookData> lookDataList = ProjectManager.getInstance().getCurrentSprite().getLookDataList();
+		LookData lookData = new LookData();
+		lookData.setLookFilename(imageFile.getName());
+		lookData.setLookName(oldLookName);
+		lookDataList.add(lookData);
+		ProjectManager.getInstance().getFileChecksumContainer()
+				.addChecksum(lookData.getChecksum(), lookData.getAbsolutePath());
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameSoundFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameSoundFragmentTest.java
@@ -33,12 +33,11 @@ import org.catrobat.catroid.common.SoundInfo;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
-import org.catrobat.catroid.ui.ScriptActivity;
-import org.catrobat.catroid.uiespresso.pocketmusic.RecyclerViewMatcher;
+import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.FileTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
-import org.catrobat.catroid.uitest.util.UiTestUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,6 +51,7 @@ import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static android.support.test.espresso.action.ViewActions.clearText;
 import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static android.support.test.espresso.action.ViewActions.typeText;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.RootMatchers.isDialog;
@@ -60,14 +60,15 @@ import static android.support.test.espresso.matcher.ViewMatchers.withContentDesc
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
+import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRVAtPosition;
 import static org.hamcrest.Matchers.allOf;
 
 @RunWith(AndroidJUnit4.class)
 public class RenameSoundFragmentTest {
 
 	@Rule
-	public BaseActivityInstrumentationRule<ScriptActivity> baseActivityTestRule = new
-			BaseActivityInstrumentationRule<>(ScriptActivity.class, true, false);
+	public BaseActivityInstrumentationRule<SpriteActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(SpriteActivity.class, true, false);
 
 	private String oldSoundName = "oldSoundName";
 	private String newSoundName = "newSoundName";
@@ -77,7 +78,7 @@ public class RenameSoundFragmentTest {
 		createProject("renameSoundFragmentTest");
 
 		Intent intent = new Intent();
-		intent.putExtra(ScriptActivity.EXTRA_FRAGMENT_POSITION, ScriptActivity.FRAGMENT_SOUNDS);
+		intent.putExtra(SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SOUNDS);
 
 		baseActivityTestRule.launchActivity(intent);
 	}
@@ -88,21 +89,18 @@ public class RenameSoundFragmentTest {
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.rename)).perform(click());
 
-		onView(new RecyclerViewMatcher(R.id.recycler_view)
-				.atPositionOnView(0, R.id.list_item_checkbox))
-				.perform(click());
+		onRVAtPosition(0)
+				.performCheckItem();
 
 		onView(withContentDescription("Done")).perform(click());
 
 		onView(withText(R.string.rename_sound_dialog)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
-		onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
-				.check(matches(isDisplayed()));
+		onView(withId(R.id.edit_text)).perform(clearText(), typeText(newSoundName), closeSoftKeyboard());
+
 		onView(allOf(withId(android.R.id.button2), withText(R.string.cancel)))
 				.check(matches(isDisplayed()));
-
-		onView(withId(R.id.edit_text)).perform(clearText(), typeText(newSoundName));
 
 		onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
 				.perform(click());
@@ -116,9 +114,8 @@ public class RenameSoundFragmentTest {
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
 		onView(withText(R.string.rename)).perform(click());
 
-		onView(new RecyclerViewMatcher(R.id.recycler_view)
-				.atPositionOnView(0, R.id.list_item_checkbox))
-				.perform(click());
+		onRVAtPosition(0)
+				.performCheckItem();
 
 		onView(withContentDescription("Done")).perform(click());
 
@@ -126,8 +123,6 @@ public class RenameSoundFragmentTest {
 				.check(matches(isDisplayed()));
 
 		onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
-				.check(matches(isDisplayed()));
-		onView(allOf(withId(android.R.id.button2), withText(R.string.cancel)))
 				.check(matches(isDisplayed()));
 
 		onView(allOf(withId(android.R.id.button2), withText(R.string.cancel)))
@@ -137,26 +132,25 @@ public class RenameSoundFragmentTest {
 	}
 
 	private void createProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 
 		Sprite sprite = new SingleSprite("testSprite");
 		project.getDefaultScene().addSprite(sprite);
 
 		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentScene(project.getDefaultScene());
 		ProjectManager.getInstance().setCurrentSprite(sprite);
 
-		File soundFile = UiTestUtils.saveFileToProject(
+		File soundFile = FileTestUtils.saveFileToProject(
 				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "longsound.mp3",
-				org.catrobat.catroid.test.R.raw.longsound, InstrumentationRegistry.getTargetContext(),
-				UiTestUtils.FileTypes.SOUND
+				org.catrobat.catroid.test.R.raw.longsound, InstrumentationRegistry.getContext(),
+				FileTestUtils.FileTypes.SOUND
 		);
 
 		List<SoundInfo> soundInfoList = ProjectManager.getInstance().getCurrentSprite().getSoundList();
 		SoundInfo soundInfo = new SoundInfo();
-		soundInfo.setSoundFileName(soundFile.getName());
-		soundInfo.setTitle(oldSoundName);
+		soundInfo.setFileName(soundFile.getName());
+		soundInfo.setName(oldSoundName);
 		soundInfoList.add(soundInfo);
-		ProjectManager.getInstance().getFileChecksumContainer()
-				.addChecksum(soundInfo.getChecksum(), soundInfo.getAbsolutePath());
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameSoundFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameSoundFragmentTest.java
@@ -1,0 +1,162 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.fragment;
+
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.SoundInfo;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.SingleSprite;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.ui.ScriptActivity;
+import org.catrobat.catroid.uiespresso.pocketmusic.RecyclerViewMatcher;
+import org.catrobat.catroid.uiespresso.testsuites.Cat;
+import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
+import org.catrobat.catroid.uitest.util.UiTestUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.List;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.action.ViewActions.clearText;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.RootMatchers.isDialog;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static org.hamcrest.Matchers.allOf;
+
+@RunWith(AndroidJUnit4.class)
+public class RenameSoundFragmentTest {
+
+	@Rule
+	public BaseActivityInstrumentationRule<ScriptActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(ScriptActivity.class, true, false);
+
+	private String oldSoundName = "oldSoundName";
+	private String newSoundName = "newSoundName";
+
+	@Before
+	public void setUp() throws Exception {
+		createProject("renameSoundFragmentTest");
+
+		Intent intent = new Intent();
+		intent.putExtra(ScriptActivity.EXTRA_FRAGMENT_POSITION, ScriptActivity.FRAGMENT_SOUNDS);
+
+		baseActivityTestRule.launchActivity(intent);
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void renameSoundFragmentTest() {
+		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
+		onView(withText(R.string.rename)).perform(click());
+
+		onView(new RecyclerViewMatcher(R.id.recycler_view)
+				.atPositionOnView(0, R.id.list_item_checkbox))
+				.perform(click());
+
+		onView(withContentDescription("Done")).perform(click());
+
+		onView(withText(R.string.rename_sound_dialog)).inRoot(isDialog())
+				.check(matches(isDisplayed()));
+
+		onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
+				.check(matches(isDisplayed()));
+		onView(allOf(withId(android.R.id.button2), withText(R.string.cancel)))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.edit_text)).perform(clearText(), typeText(newSoundName));
+
+		onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
+				.perform(click());
+
+		onView(withText(newSoundName)).check(matches(isDisplayed()));
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void cancelRenameSoundFragmentTest() {
+		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext());
+		onView(withText(R.string.rename)).perform(click());
+
+		onView(new RecyclerViewMatcher(R.id.recycler_view)
+				.atPositionOnView(0, R.id.list_item_checkbox))
+				.perform(click());
+
+		onView(withContentDescription("Done")).perform(click());
+
+		onView(withText(R.string.rename_sound_dialog)).inRoot(isDialog())
+				.check(matches(isDisplayed()));
+
+		onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
+				.check(matches(isDisplayed()));
+		onView(allOf(withId(android.R.id.button2), withText(R.string.cancel)))
+				.check(matches(isDisplayed()));
+
+		onView(allOf(withId(android.R.id.button2), withText(R.string.cancel)))
+				.perform(click());
+
+		onView(withText(oldSoundName)).check(matches(isDisplayed()));
+	}
+
+	private void createProject(String projectName) {
+		Project project = new Project(null, projectName);
+
+		Sprite sprite = new SingleSprite("testSprite");
+		project.getDefaultScene().addSprite(sprite);
+
+		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite);
+
+		File soundFile = UiTestUtils.saveFileToProject(
+				projectName, ProjectManager.getInstance().getCurrentScene().getName(), "longsound.mp3",
+				org.catrobat.catroid.test.R.raw.longsound, InstrumentationRegistry.getTargetContext(),
+				UiTestUtils.FileTypes.SOUND
+		);
+
+		List<SoundInfo> soundInfoList = ProjectManager.getInstance().getCurrentSprite().getSoundList();
+		SoundInfo soundInfo = new SoundInfo();
+		soundInfo.setSoundFileName(soundFile.getName());
+		soundInfo.setTitle(oldSoundName);
+		soundInfoList.add(soundInfo);
+		ProjectManager.getInstance().getFileChecksumContainer()
+				.addChecksum(soundInfo.getChecksum(), soundInfo.getAbsolutePath());
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/rvutils/RecyclerViewInteractionWrapper.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/rvutils/RecyclerViewInteractionWrapper.java
@@ -1,0 +1,57 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.fragment.rvutils;
+
+import android.support.test.espresso.ViewInteraction;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.uiespresso.util.wrappers.ViewInteractionWrapper;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+
+public class RecyclerViewInteractionWrapper extends ViewInteractionWrapper {
+	private static int recyclerViewId = R.id.recycler_view;
+	private int position;
+
+	private RecyclerViewInteractionWrapper(ViewInteraction viewInteraction, int position) {
+		super(viewInteraction);
+		this.position = position;
+	}
+
+	public static RecyclerViewInteractionWrapper onRVAtPosition(int position) {
+		return new RecyclerViewInteractionWrapper(
+				onView(new RecyclerViewMatcher(recyclerViewId).withPosition(position)), position);
+	}
+
+	public ViewInteraction onChildView(int childViewId) {
+		return onView(new RecyclerViewMatcher(recyclerViewId).withIdInsidePosition(childViewId, position));
+	}
+
+	public RecyclerViewInteractionWrapper performCheckItem() {
+		onChildView(R.id.list_item_checkbox)
+				.perform(click());
+		return this;
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/rvutils/RecyclerViewMatcher.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/rvutils/RecyclerViewMatcher.java
@@ -1,0 +1,78 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.fragment.rvutils;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+public class RecyclerViewMatcher {
+	private final int recyclerViewId;
+
+	public RecyclerViewMatcher(int recyclerViewId) {
+		this.recyclerViewId = recyclerViewId;
+	}
+
+	public Matcher<View> withPosition(final int position) {
+
+		return new TypeSafeMatcher<View>() {
+			public void describeTo(Description description) {
+				description.appendText("RecyclerViewMatcher at position: " + Integer.toString(position)
+						+ "does not match the view");
+			}
+
+			public boolean matchesSafely(View view) {
+				RecyclerView recyclerView =
+						(RecyclerView) view.getRootView().findViewById(recyclerViewId);
+				return recyclerView != null &&
+						recyclerView.getId() == recyclerViewId &&
+						recyclerView.findViewHolderForAdapterPosition(position) != null &&
+						view == recyclerView.findViewHolderForAdapterPosition(position).itemView;
+			}
+		};
+	}
+
+	public Matcher<View> withIdInsidePosition(final int viewId, final int position) {
+
+		return new TypeSafeMatcher<View>() {
+			public void describeTo(Description description) {
+				description.appendText("RecyclerViewMatcher with Id: "  + viewId + "inside position: "
+						+ Integer.toString(position) + "does not match the view");
+			}
+
+			public boolean matchesSafely(View view) {
+				RecyclerView recyclerView =
+						(RecyclerView) view.getRootView().findViewById(recyclerViewId);
+				return recyclerView != null &&
+						recyclerView.getId() == recyclerViewId &&
+						recyclerView.findViewHolderForAdapterPosition(position)!= null &&
+						view == recyclerView.findViewHolderForAdapterPosition(position).itemView
+								.findViewById(viewId);
+			}
+		};
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/UiTestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/UiTestUtils.java
@@ -68,7 +68,7 @@ public final class UiTestUtils {
 	}
 
 	public static Project createEmptyProject(String projectName) {
-		Project project = new Project(null, projectName);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
 		Sprite sprite = new Sprite("testSprite");
 		Script script = new StartScript();
 		sprite.addScript(script);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/rules/DontGenerateDefaultProjectActivityInstrumentationRule.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/rules/DontGenerateDefaultProjectActivityInstrumentationRule.java
@@ -23,6 +23,7 @@
 package org.catrobat.catroid.uiespresso.util.rules;
 
 import android.app.Activity;
+import android.support.test.InstrumentationRegistry;
 
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.content.Project;
@@ -51,7 +52,8 @@ public class DontGenerateDefaultProjectActivityInstrumentationRule<T extends Act
 	void setUpDummyProject() {
 		File newUiTestFolder = new File(Constants.DEFAULT_ROOT);
 		newUiTestFolder.mkdir();
-		Project project = new Project(null, "DummyToPreventDefaultProjectCreation");
+		Project project = new Project(InstrumentationRegistry.getTargetContext(),
+				"DummyToPreventDefaultProjectCreation");
 		StorageHandler.getInstance().saveProject(project);
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -30,6 +30,7 @@ import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Rect;
+import android.support.test.InstrumentationRegistry;
 import android.test.ActivityInstrumentationTestCase2;
 import android.text.InputType;
 import android.util.Log;
@@ -762,7 +763,7 @@ public final class UiTestUtils {
 	}
 
 	public static void createEmptyProject() {
-		Project project = new Project(null, DEFAULT_TEST_PROJECT_NAME);
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), DEFAULT_TEST_PROJECT_NAME);
 		Sprite firstSprite = new SingleSprite("cat");
 		Script testScript = new StartScript();
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
@@ -66,6 +66,7 @@ public class SpriteActivity extends BaseActivity implements PlaySceneDialog.Play
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		SettingsActivity.setToChosenLanguage(this);
 
 		setContentView(R.layout.activity_script);
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/SpriteAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/SpriteAdapter.java
@@ -31,6 +31,7 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
 
 import java.util.List;
+import java.util.Locale;
 
 public class SpriteAdapter extends RecyclerViewAdapter<Sprite> {
 
@@ -60,20 +61,20 @@ public class SpriteAdapter extends RecyclerViewAdapter<Sprite> {
 			holder.leftBottomDetails.setText(context
 					.getString(R.string.number_of_scripts)
 					.concat(" ")
-					.concat(Integer.toString(item.getNumberOfScripts())));
+					.concat(String.format(Locale.getDefault(), "%d", item.getNumberOfScripts())));
 			holder.rightBottomDetails.setText(context
 					.getString(R.string.number_of_bricks)
 					.concat(" ")
-					.concat(Integer.toString(item.getNumberOfBricks())));
+					.concat(String.format(Locale.getDefault(), "%d", item.getNumberOfBricks())));
 
 			holder.leftTopDetails.setText(context
 					.getString(R.string.number_of_looks)
 					.concat(" ")
-					.concat(Integer.toString(item.getLookList().size())));
+					.concat(String.format(Locale.getDefault(), "%d", item.getLookList().size())));
 			holder.rightTopDetails.setText(context
 					.getString(R.string.number_of_sounds)
 					.concat(" ")
-					.concat(Integer.toString(item.getSoundList().size())));
+					.concat(String.format(Locale.getDefault(), "%d", item.getSoundList().size())));
 		} else {
 			holder.details.setVisibility(View.GONE);
 		}


### PR DESCRIPTION
- **BroadcastBricksTest**.class
 known bug, fails also in develop
- **DeleteItemOfUserListBrickTest**.class, 
fails rightly, user list still available in bricks spinner
- **IfThenBrickTest**.class,
fails, probably not rightly, looping brick references wrong, something took care of this in the past when creating projects in that manner, but not anymore....
- **IfThenElseBrickTest**.class, 
fails, probably not rightly, looping brick references wrong, something took care of this in the past when creating projects in that manner, but not anymore....
- **FormulaEditorKeyboardTest**.class, 
fails rightly, something majorly wrong with formula editor
- **ObjectVariableTest**.class, 
fails rightly, something wrong with layer change / initial layer in which sprite lives
- **ProjectActivityNumberOfBricksRegressionTest**.class, 
fails rightly, number of bricks incorrect
- **HindiNumberAtShowDetailsAtProjectActivityTest**.class,
fails rightly, number of bricks incorrect